### PR TITLE
Improve Mihoro subscription and proxy controls

### DIFF
--- a/ClashApi.js
+++ b/ClashApi.js
@@ -159,12 +159,17 @@ function parseVersion(body) {
 function parseConfigs(body) {
   var payload = parseJson(body)
   if (!payload) return null
+  var tun = payload.tun
+  var tunEnabled = tun && typeof tun === "object" && typeof tun.enable === "boolean"
+    ? tun.enable
+    : null
   return {
     mode: normalizeMode(payload.mode),
     port: Number(payload.port) || 0,
     socksPort: Number(payload["socks-port"]) || 0,
     mixedPort: Number(payload["mixed-port"]) || 0,
     allowLan: payload["allow-lan"] === true,
+    tunEnabled: tunEnabled,
     logLevel: String(payload["log-level"] || "")
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 QMLLINT := /usr/lib/qt6/bin/qmllint
 QML_FILES := Panel.qml Service.qml \
 	components/MihoroIcon.qml \
+	components/SettingsIcon.qml \
 	components/StatRow.qml \
 	components/ModeSection.qml \
 	components/ConnectionSection.qml \

--- a/Model.js
+++ b/Model.js
@@ -36,6 +36,7 @@ function applyCommand() { return ["mihoro", "apply"] }
 function startCommand() { return ["mihoro", "start"] }
 function stopCommand() { return ["mihoro", "stop"] }
 function restartCommand() { return ["mihoro", "restart"] }
+function proxyExportCommand() { return ["mihoro", "proxy", "export"] }
 
 // One probe per refresh instead of five processes. It answers: is the CLI on
 // PATH, what does systemd think of mihomo.service, when did it last come up,
@@ -224,32 +225,17 @@ function subscriptionUrlError(url) {
   return ""
 }
 
-var MASK = "••••••"
+var MASK = "*******"
 
 // A subscription URL is a bearer credential: the token is the whole of the
-// authentication. It is masked whole rather than partially, because a panel in
-// a bar is read over shoulders and half a token is still half a token.
+// authentication. Keep only the origin recognizable; paths, query names,
+// values, and fragments can all identify an account or expose credentials.
 function maskUrl(url) {
   var text = String(url === undefined || url === null ? "" : url).trim()
   if (text === "") return ""
-  var parts = text.match(/^([a-z][a-z0-9+.\-]*:\/\/)([^\/?#]*)([^?#]*)(\?[^#]*)?(#.*)?$/i)
+  var parts = text.match(/^([a-z][a-z0-9+.\-]*:\/\/)([^\/?#]+)/i)
   if (!parts) return MASK
-
-  var path = String(parts[3] || "").split("/").map(function(segment) {
-    return segment.length >= 12 ? MASK : segment
-  }).join("/")
-
-  var query = String(parts[4] || "")
-  if (query !== "") {
-    query = "?" + query.substring(1).split("&").map(function(pair) {
-      var eq = pair.indexOf("=")
-      if (eq < 0) return pair.length >= 8 ? MASK : pair
-      var value = pair.substring(eq + 1)
-      return pair.substring(0, eq) + "=" + (value.length >= 8 ? MASK : value)
-    }).join("&")
-  }
-
-  return String(parts[1]) + String(parts[2]) + path + query + (parts[5] ? MASK : "")
+  return String(parts[1]) + String(parts[2]) + "/" + MASK
 }
 
 function displayUrl(url, revealed) {

--- a/Panel.qml
+++ b/Panel.qml
@@ -21,16 +21,18 @@ Panel {
   property bool cursorActive: false
   property int cursorIndex: 0
   property int modeCursor: 0
+  property int panelPage: 1
 
   // One flat list of what the keyboard can reach, rebuilt from the service
   // state. A panel this shallow does not need per-section cursors: the order
   // here is the order on screen.
   readonly property var targets: {
     if (!mihoro.probe.mihoroInstalled) return ["setup"]
-    if (!mihoro.initialized) return ["setup", "url"]
+    if (root.panelPage === 2) return ["update", "edit"]
+    if (!mihoro.initialized) return ["setup"]
     var list = ["power"]
     if (mihoro.canSwitchMode) list.push("mode")
-    list.push("url", "update")
+    list.push("subscription")
     return list
   }
 
@@ -72,12 +74,33 @@ Panel {
     var target = cursorTarget
     if (target === "power") mihoro.toggleService()
     else if (target === "mode") mihoro.setMode(Model.MODES[modeCursor].value)
-    else if (target === "url") subscription.beginEdit()
+    else if (target === "subscription") root.openSubscriptionPage()
+    else if (target === "edit") subscription.beginEdit()
     else if (target === "update") mihoro.updateSubscription()
     else if (target === "setup") {
       if (!mihoro.probe.mihoroInstalled) Quickshell.execDetached(["xdg-open", Model.INSTALL_DOCS_URL])
-      else subscription.beginEdit()
+      else {
+        root.openSubscriptionPage()
+        subscription.beginEdit()
+      }
     }
+  }
+
+  function openSubscriptionPage() {
+    panelPage = 2
+    cursorActive = false
+    cursorIndex = 0
+    if (panelFlick) panelFlick.contentY = 0
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function leaveSubscriptionPage() {
+    subscription.cancelEdit()
+    panelPage = 1
+    cursorActive = false
+    cursorIndex = 0
+    if (panelFlick) panelFlick.contentY = 0
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
 
   function cycleMode(delta) {
@@ -93,6 +116,8 @@ Panel {
   }
 
   onOpenedChanged: if (opened) {
+    subscription.cancelEdit()
+    panelPage = 1
     cursorActive = false
     cursorIndex = 0
     modeCursor = Model.modeIndex(mihoro.mode)
@@ -154,7 +179,7 @@ Panel {
       Item {
         MihoroIcon {
           anchors.centerIn: parent
-          iconSize: Style.space(11)
+          iconSize: Style.space(12)
           color: button.glyphColor
           badgeColor: Color.urgent
           crossed: !mihoro.active
@@ -192,18 +217,22 @@ Panel {
         root.moveCursor(dx, dy)
       }
       onActivateRequested: if (root.cursorActive) root.activateCursor()
-      onCloseRequested: root.close()
+      onCloseRequested: {
+        if (root.panelPage === 2) root.leaveSubscriptionPage()
+        else root.close()
+      }
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(text) {
         var key = String(text || "").toLowerCase()
-        if (key === "t") mihoro.toggleService()
-        else if (key === "r") mihoro.refresh()
-        else if (key === "u") mihoro.updateSubscription()
-        else if (key === "e") subscription.beginEdit()
-        else if (key === "m") root.cycleMode(1)
-        else if (key === "1") mihoro.setMode("rule")
-        else if (key === "2") mihoro.setMode("global")
-        else if (key === "3") mihoro.setMode("direct")
+        if (root.panelPage === 2 && key === "u") mihoro.updateSubscription()
+        else if (root.panelPage === 2 && key === "e") subscription.beginEdit()
+        else if (root.panelPage === 1 && key === "t") mihoro.toggleService()
+        else if (root.panelPage === 1 && key === "r") mihoro.refresh()
+        else if (root.panelPage === 1 && key === "s") root.openSubscriptionPage()
+        else if (root.panelPage === 1 && key === "m") root.cycleMode(1)
+        else if (root.panelPage === 1 && key === "1") mihoro.setMode("rule")
+        else if (root.panelPage === 1 && key === "2") mihoro.setMode("global")
+        else if (root.panelPage === 1 && key === "3") mihoro.setMode("direct")
       }
 
       Flickable {
@@ -224,6 +253,7 @@ Panel {
 
           Item {
             id: header
+            visible: root.panelPage === 1
             width: parent.width
             implicitHeight: Math.max(hero.implicitHeight, headerControls.implicitHeight)
 
@@ -286,7 +316,9 @@ Panel {
                 panelFontFamily: root.fontFamily
                 dashboardUrl: root.dashboardUrl
                 canRestart: mihoro.initialized && mihoro.probe.unitLoaded
+                canCopyProxy: mihoro.probe.mihoroInstalled && !mihoro.copyingProxyExport
                 onRestartRequested: mihoro.restartService()
+                onCopyProxyRequested: mihoro.copyProxyExport()
               }
             }
           }
@@ -294,7 +326,7 @@ Panel {
           // One line for whatever the panel most needs to say: what it is
           // doing, what went wrong, or why the proxy is not connected.
           Text {
-            visible: text !== ""
+            visible: root.panelPage === 1 && text !== ""
             width: parent.width
             text: mihoro.actionStatus !== "" ? mihoro.actionStatus
               : (mihoro.lastError !== "" ? mihoro.lastError : mihoro.connection.detail)
@@ -305,23 +337,26 @@ Panel {
           }
 
           SetupCard {
-            visible: !mihoro.probe.mihoroInstalled || !mihoro.initialized
+            visible: root.panelPage === 1 && (!mihoro.probe.mihoroInstalled || !mihoro.initialized)
             width: parent.width
             textColor: root.foreground
             panelFontFamily: root.fontFamily
             stateKey: mihoro.probe.mihoroInstalled ? "not_initialized" : "cli_missing"
             busy: mihoro.busy
             hasCursor: root.cursorTarget === "setup"
-            onAddUrlRequested: subscription.beginEdit()
+            onAddUrlRequested: {
+              root.openSubscriptionPage()
+              subscription.beginEdit()
+            }
           }
 
           PanelSeparator {
-            visible: mihoro.initialized
+            visible: root.panelPage === 1 && mihoro.initialized
             foreground: root.foreground
           }
 
           ModeSection {
-            visible: mihoro.initialized
+            visible: root.panelPage === 1 && mihoro.initialized
             width: parent.width
             textColor: root.foreground
             panelFontFamily: root.fontFamily
@@ -331,6 +366,7 @@ Panel {
             hint: mihoro.modeHint
             cursorIndex: root.cursorTarget === "mode" ? root.modeCursor : -1
             onModeRequested: function(value) { mihoro.setMode(value) }
+            onSubscriptionRequested: root.openSubscriptionPage()
             onChipHovered: function(index, isHovered) {
               if (!isHovered || !mihoro.canSwitchMode) return
               root.cursorActive = true
@@ -340,31 +376,27 @@ Panel {
           }
 
           PanelSeparator {
-            visible: mihoro.initialized
+            visible: root.panelPage === 1 && mihoro.initialized
             foreground: root.foreground
           }
 
           ConnectionSection {
-            visible: mihoro.initialized
+            visible: root.panelPage === 1 && mihoro.initialized
             width: parent.width
             service: mihoro
             textColor: root.foreground
             panelFontFamily: root.fontFamily
           }
 
-          PanelSeparator {
-            visible: mihoro.probe.mihoroInstalled
-            foreground: root.foreground
-          }
-
           SubscriptionSection {
             id: subscription
-            visible: mihoro.probe.mihoroInstalled
+            visible: root.panelPage === 2 && mihoro.probe.mihoroInstalled
             width: parent.width
             service: mihoro
             textColor: root.foreground
             panelFontFamily: root.fontFamily
             cursorTarget: root.cursorTarget
+            onBackRequested: root.leaveSubscriptionPage()
             onUrlCommitted: function(url) { mihoro.setSubscriptionUrl(url) }
             onUpdateRequested: mihoro.updateSubscription()
             onEditingChanged: if (!editing) Qt.callLater(function() { keyCatcher.forceActiveFocus() })

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 An Omarchy bar panel for [mihoro](https://github.com/spencerwooo/mihoro), the
 Mihomo CLI client for Linux.
 
+<img width="621" height="720" alt="Mihoro panel" src="https://github.com/user-attachments/assets/ca5a27d9-a05e-4134-8cae-360ddef861d8" />
+
 It does three things: shows what the proxy is actually doing, manages the
 subscription URL, and switches between Rule, Global, and Direct.
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,9 @@ would show a subscription the proxy is not actually using. On a machine that
 has never been set up, saving runs `mihoro init -y` instead, which downloads
 the core, the config, and installs the service.
 
-The URL is masked by default and revealed with a button. It is a bearer
-credential — whoever has it has the subscription — and a bar panel gets read
-over shoulders, so the token is hidden whole rather than partially. Half a
-token is still half a token.
+The URL is never rendered in read-only mode. It is a bearer credential —
+whoever has it has the subscription — and only enters a control after you
+explicitly choose Edit.
 
 Writes are line-level replacements, not a parse-and-reserialize round trip.
 Everything else in `mihoro.toml` is yours: key order, blank lines, comments,

--- a/README.md
+++ b/README.md
@@ -17,10 +17,38 @@ schedules it. When mihoro is missing the panel says so and links to the
 official instructions; it never downloads or runs an installer, and it never
 asks for root.
 
-## Install
+## Getting Started
+
+Install mihoro:
 
 ```bash
-omarchy plugin add https://github.com/<you>/omahoro.git --enable
+curl -fsSL https://raw.githubusercontent.com/spencerwooo/mihoro/main/install.sh | sh
+```
+
+Initialize mihoro and enter your subscription URL when prompted:
+
+```bash
+mihoro init
+```
+
+Set the capabilities required for TUN mode, confirm them, and restart mihomo:
+
+```bash
+sudo setcap cap_net_admin,cap_net_raw,cap_net_bind_service=+ep ~/.local/bin/mihomo
+getcap ~/.local/bin/mihomo
+systemctl --user restart mihomo.service
+```
+
+Verify that the service started successfully:
+
+```bash
+journalctl --user -u mihomo.service -n 30 --no-pager
+```
+
+## Install the Plugin
+
+```bash
+omarchy plugin add https://github.com/huacnlee/omarchy-mihoro.git --enable
 ```
 
 For development, symlink this checkout into Omarchy:
@@ -134,10 +162,11 @@ anywhere; the control goes quiet and says to start mihomo instead.
 - `enter`: activate
 - `t`: start or stop mihomo
 - `1` / `2` / `3`: Rule / Global / Direct, `m` to cycle
-- `u`: update the subscription
-- `e`: edit the subscription URL
+- `s`: open subscription management
+- `u`: update the subscription (subscription page)
+- `e`: edit the subscription URL (subscription page)
 - `r`: refresh
-- `esc`: close, or leave the URL editor
+- `esc`: leave URL editing, return to the main page, then close
 
 While the URL editor is open every key belongs to it — a URL contains `r` and
 `u`.

--- a/Service.qml
+++ b/Service.qml
@@ -77,6 +77,7 @@ Item {
   readonly property bool busy: probeProcess.running || configReadProcess.running
     || actionProcess.running || modeProcess.running || configWriteProcess.running
   readonly property bool actionRunning: actionProcess.running
+  readonly property bool copyingProxyExport: proxyExportProcess.running || clipboardProcess.running
 
   signal actionFinished(string kind, bool ok)
 
@@ -168,6 +169,15 @@ Item {
     runAction("update", Model.updateConfigCommand(), "Refreshing subscription…")
   }
 
+  function copyProxyExport() {
+    if (!probe.mihoroInstalled || copyingProxyExport) return
+    _pendingClipboard = ""
+    lastError = ""
+    actionStatus = "Exporting proxy info…"
+    proxyExportProcess.command = Model.proxyExportCommand()
+    proxyExportProcess.running = true
+  }
+
   // Setting the URL and pulling it are one gesture: writing the file alone
   // would leave the panel showing a subscription that nothing has fetched.
   function setSubscriptionUrl(url) {
@@ -198,6 +208,7 @@ Item {
   property string _afterWrite: ""
   property string _actionOutput: ""
   property string _actionError: ""
+  property string _pendingClipboard: ""
 
   function writeConfig(changes, thenAction) {
     if (configWriteProcess.running) return false
@@ -431,6 +442,42 @@ Item {
       // The stream ends whenever mihomo restarts or the network blips. Come
       // back on a delay rather than spinning on a core that is still booting.
       if (root.panelOpen) trafficRetry.restart()
+    }
+  }
+
+  Process {
+    id: proxyExportProcess
+    running: false
+    command: []
+    stdout: SplitParser {
+      onRead: function(line) { root._pendingClipboard += line + "\n" }
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0 || root._pendingClipboard.trim() === "") {
+        root._pendingClipboard = ""
+        root.actionStatus = ""
+        root.lastError = "Could not export proxy info."
+        return
+      }
+      clipboardProcess.stdinEnabled = true
+      clipboardProcess.running = true
+    }
+  }
+
+  Process {
+    id: clipboardProcess
+    running: false
+    command: ["wl-copy"]
+    stdinEnabled: false
+    onStarted: {
+      clipboardProcess.write(root._pendingClipboard)
+      root._pendingClipboard = ""
+      clipboardProcess.stdinEnabled = false
+    }
+    onExited: function(exitCode) {
+      root.actionStatus = exitCode === 0 ? "Proxy export copied." : ""
+      root.lastError = exitCode === 0 ? "" : "Could not copy proxy info."
+      if (exitCode === 0) actionStatusTimer.restart()
     }
   }
 

--- a/components/ConnectionSection.qml
+++ b/components/ConnectionSection.qml
@@ -28,17 +28,24 @@ Column {
   }
 
   Row {
+    id: trafficRow
     width: parent.width
-    spacing: Style.space(18)
+    spacing: Style.space(10)
     opacity: root.live ? 1.0 : 0.45
 
     Speed {
+      width: (trafficRow.width - trafficRow.spacing) / 2
       glyph: "↓"
+      label: "DOWNLOAD"
+      metricColor: Color.accent
       value: Model.formatSpeed(root.service.downSpeed)
     }
 
     Speed {
+      width: (trafficRow.width - trafficRow.spacing) / 2
       glyph: "↑"
+      label: "UPLOAD"
+      metricColor: Color.urgent
       value: Model.formatSpeed(root.service.upSpeed)
     }
   }
@@ -126,6 +133,21 @@ Column {
       width: parent.width
       textColor: root.textColor
       panelFontFamily: root.panelFontFamily
+      label: "TUN"
+      value: {
+        var liveConfig = root.service.liveConfigs
+        if (!liveConfig || liveConfig.tunEnabled === null) return "—"
+        return liveConfig.tunEnabled ? "enabled" : "disabled"
+      }
+      valueColor: root.service.liveConfigs && root.service.liveConfigs.tunEnabled === true
+        ? Color.accent
+        : root.textColor
+    }
+
+    StatRow {
+      width: parent.width
+      textColor: root.textColor
+      panelFontFamily: root.panelFontFamily
       label: "LAN access"
       value: {
         var liveConfig = root.service.liveConfigs
@@ -138,17 +160,40 @@ Column {
   component Speed: Item {
     id: speed
     required property string glyph
+    required property string label
     required property string value
+    required property color metricColor
 
-    implicitWidth: speedText.implicitWidth
-    implicitHeight: speedText.implicitHeight
+    implicitHeight: metricContent.implicitHeight + Style.space(20)
 
-    Text {
-      id: speedText
-      text: speed.glyph + " " + speed.value
-      color: root.textColor
-      font.family: root.panelFontFamily
-      font.pixelSize: Style.font.title
+    Column {
+      id: metricContent
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: Style.space(8)
+      anchors.rightMargin: Style.space(8)
+      spacing: Style.space(3)
+
+      Text {
+        width: parent.width
+        text: speed.glyph + "  " + speed.label
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        font.bold: true
+        horizontalAlignment: Text.AlignHCenter
+      }
+
+      Text {
+        width: parent.width
+        text: speed.value
+        color: speed.metricColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.title
+        font.bold: true
+        horizontalAlignment: Text.AlignHCenter
+      }
     }
   }
 }

--- a/components/ModeSection.qml
+++ b/components/ModeSection.qml
@@ -23,6 +23,7 @@ Column {
 
   signal modeRequested(string value)
   signal chipHovered(int index, bool isHovered)
+  signal subscriptionRequested()
 
   readonly property var options: Model.MODES.map(function(entry) {
     return { value: entry.value, label: entry.label, tooltip: entry.hint }
@@ -55,23 +56,48 @@ Column {
     }
   }
 
-  ButtonGroup {
-    id: group
+  Row {
+    id: modeControlRow
     width: parent.width
-    options: root.options
-    value: root.mode
-    foreground: root.textColor
-    accent: root.accentColor
-    fontFamily: root.panelFontFamily
-    fontSize: Style.font.bodySmall
-    // The panel drives the cursor; Tab focus would give the group a second,
-    // competing highlight inside a surface that already has one.
-    focusable: false
-    cursorIndex: root.cursorIndex
-    opacity: root.switchable ? 1.0 : 0.45
-    enabled: root.switchable
-    onChanged: function(value) { if (root.switchable) root.modeRequested(value) }
-    onHovered: function(index, isHovered) { root.chipHovered(index, isHovered) }
+    spacing: Style.space(6)
+
+    ButtonGroup {
+      id: group
+      anchors.verticalCenter: parent.verticalCenter
+      width: modeControlRow.width - subscriptionButton.width - modeControlRow.spacing
+      options: root.options
+      value: root.mode
+      foreground: root.textColor
+      accent: root.accentColor
+      fontFamily: root.panelFontFamily
+      fontSize: Style.font.bodySmall
+      // The panel drives the cursor; Tab focus would give the group a second,
+      // competing highlight inside a surface that already has one.
+      focusable: false
+      cursorIndex: root.cursorIndex
+      opacity: root.switchable ? 1.0 : 0.45
+      enabled: root.switchable
+      onChanged: function(value) { if (root.switchable) root.modeRequested(value) }
+      onHovered: function(index, isHovered) { root.chipHovered(index, isHovered) }
+    }
+
+    PanelActionButton {
+      id: subscriptionButton
+      anchors.verticalCenter: parent.verticalCenter
+      foreground: root.textColor
+      hoverColor: root.textColor
+      size: Style.space(26)
+      tooltipText: "Manage subscription"
+      onClicked: root.subscriptionRequested()
+
+      SettingsIcon {
+        anchors.centerIn: parent
+        iconSize: Style.font.body
+        color: subscriptionButton._hot
+          ? subscriptionButton.hoverColor
+          : subscriptionButton.foreground
+      }
+    }
   }
 
   Text {

--- a/components/PanelMenu.qml
+++ b/components/PanelMenu.qml
@@ -14,8 +14,10 @@ Item {
   required property string panelFontFamily
   property string dashboardUrl: ""
   property bool canRestart: false
+  property bool canCopyProxy: false
 
   signal restartRequested()
+  signal copyProxyRequested()
 
   implicitWidth: Style.space(28)
   implicitHeight: Style.space(28)
@@ -59,6 +61,10 @@ Item {
         enabled: root.dashboardUrl !== ""
         onActivated: root.openUrl(root.dashboardUrl)
       }
+      MenuRow {
+        text: "GitHub"
+        onActivated: root.openUrl("https://github.com/huacnlee/omarchy-mihoro")
+      }
       MenuRow { text: "mihoro"; onActivated: root.openUrl("https://github.com/spencerwooo/mihoro") }
       MenuRow { text: "mihomo docs"; onActivated: root.openUrl("https://wiki.metacubex.one") }
 
@@ -70,6 +76,15 @@ Item {
           anchors.verticalCenter: parent.verticalCenter
           width: parent.width
           foreground: root.textColor
+        }
+      }
+
+      MenuRow {
+        text: "Copy proxy export"
+        enabled: root.canCopyProxy
+        onActivated: {
+          menu.close()
+          root.copyProxyRequested()
         }
       }
 

--- a/components/SettingsIcon.qml
+++ b/components/SettingsIcon.qml
@@ -1,0 +1,59 @@
+import QtQuick
+import qs.Commons
+
+// A small monochrome gear for compact panel actions. Drawing it here avoids
+// the platform-dependent colour emoji used for the Unicode gear character.
+Item {
+  id: root
+
+  property real iconSize: Style.font.icon
+  property color color: Color.foreground
+
+  width: iconSize
+  height: iconSize
+  implicitWidth: iconSize
+  implicitHeight: iconSize
+
+  onColorChanged: gear.requestPaint()
+  onIconSizeChanged: gear.requestPaint()
+
+  Canvas {
+    id: gear
+    anchors.fill: parent
+    antialiasing: true
+
+    onPaint: {
+      var ctx = getContext("2d")
+      ctx.reset()
+      var size = Math.min(width, height)
+      if (size <= 0) return
+
+      var cx = width / 2
+      var cy = height / 2
+      var outer = size * 0.43
+      var body = size * 0.31
+      var hole = size * 0.12
+      var stroke = Math.max(1.25, size * 0.11)
+
+      ctx.strokeStyle = root.color
+      ctx.lineWidth = stroke
+      ctx.lineCap = "round"
+
+      for (var i = 0; i < 8; ++i) {
+        var angle = i * Math.PI / 4
+        ctx.beginPath()
+        ctx.moveTo(cx + Math.cos(angle) * body, cy + Math.sin(angle) * body)
+        ctx.lineTo(cx + Math.cos(angle) * outer, cy + Math.sin(angle) * outer)
+        ctx.stroke()
+      }
+
+      ctx.beginPath()
+      ctx.arc(cx, cy, body, 0, Math.PI * 2)
+      ctx.stroke()
+
+      ctx.beginPath()
+      ctx.arc(cx, cy, hole, 0, Math.PI * 2)
+      ctx.stroke()
+    }
+  }
+}

--- a/components/SubscriptionSection.qml
+++ b/components/SubscriptionSection.qml
@@ -9,15 +9,14 @@ import "../Model.js" as Model
 // it are one action here — a saved URL that nothing has downloaded would show a
 // subscription the proxy is not actually using.
 //
-// The URL is masked by default. It is a bearer credential: whoever has it has
-// the subscription, and a bar panel is read over shoulders.
+// The URL is a bearer credential, so read-only mode never renders it. It only
+// enters a control after the user explicitly chooses Edit/Add.
 Column {
   id: root
 
   required property var service
   required property color textColor
   required property string panelFontFamily
-  property bool revealed: false
   property bool editing: false
   property string cursorTarget: ""
 
@@ -48,7 +47,7 @@ Column {
 
   Item {
     width: parent.width
-    implicitHeight: Math.max(sectionHeader.implicitHeight, updatedLabel.implicitHeight)
+    implicitHeight: sectionHeader.implicitHeight
 
     Row {
       id: sectionHeader
@@ -72,51 +71,59 @@ Column {
       }
     }
 
-    Text {
-      id: updatedLabel
-      anchors.right: parent.right
+  }
+
+  Rectangle {
+    id: subscriptionStatus
+    visible: !root.editing && root.service.probe.configPresent
+    width: parent.width
+    implicitHeight: Style.space(38)
+    radius: Style.cornerRadius
+    color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.04)
+    border.width: 1
+    border.color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.12)
+
+    Row {
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(10)
       anchors.verticalCenter: parent.verticalCenter
-      visible: root.service.probe.configPresent
-      text: "updated " + Model.formatAgo(root.service.probe.configMtime, root.service.probe.now)
+      spacing: Style.space(7)
+
+      Rectangle {
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(6)
+        height: width
+        radius: width / 2
+        color: Color.accent
+      }
+
+      Text {
+        text: "Configured"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+    }
+
+    Text {
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      text: "Last updated " + Model.formatAgo(root.service.probe.configMtime, root.service.probe.now)
       color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.caption
     }
   }
 
-  // ---- read-only view
-  QQC.TextField {
-    id: urlDisplay
-    visible: !root.editing
-    width: parent.width
-    implicitHeight: Style.space(40)
-    readOnly: true
-    focusPolicy: Qt.NoFocus
-    selectByMouse: false
-    text: Model.displayUrl(root.url, root.revealed)
-    color: root.url === ""
-      ? Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
-      : root.textColor
-    font.family: root.panelFontFamily
-    font.pixelSize: Style.font.bodySmall
-    leftPadding: Style.space(10)
-    rightPadding: Style.space(10)
-    topPadding: Style.space(8)
-    bottomPadding: Style.space(8)
-    background: Rectangle {
-      radius: Style.cornerRadius
-      color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.04)
-      border.width: 1
-      border.color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.16)
-    }
-  }
-
   Row {
+    id: subscriptionActions
     visible: !root.editing
     width: parent.width
     spacing: Style.spacing.controlGap
 
     Button {
+      width: (subscriptionActions.width - subscriptionActions.spacing) / 2
       text: root.updating ? "Updating…" : "Update"
       foreground: root.textColor
       bordered: true
@@ -127,6 +134,7 @@ Column {
     }
 
     Button {
+      width: (subscriptionActions.width - subscriptionActions.spacing) / 2
       text: root.url === "" ? "Add" : "Edit"
       foreground: root.textColor
       bordered: true
@@ -136,14 +144,6 @@ Column {
       onClicked: root.beginEdit()
     }
 
-    Button {
-      visible: root.url !== ""
-      text: root.revealed ? "Hide" : "Show"
-      foreground: root.textColor
-      bordered: false
-      fontSize: Style.font.bodySmall
-      onClicked: root.revealed = !root.revealed
-    }
   }
 
   // ---- editor
@@ -151,6 +151,12 @@ Column {
     visible: root.editing
     width: parent.width
     spacing: Style.space(8)
+
+    PanelSectionHeader {
+      text: "SUBSCRIPTION URL"
+      foreground: root.textColor
+      fontFamily: root.panelFontFamily
+    }
 
     QQC.TextArea {
       id: field
@@ -197,9 +203,12 @@ Column {
     }
 
     Row {
+      id: editorActions
+      width: parent.width
       spacing: Style.spacing.controlGap
 
       Button {
+        width: (editorActions.width - editorActions.spacing) / 2
         text: root.service.probe.configPresent ? "Update" : "Save and set up"
         foreground: root.textColor
         bordered: true
@@ -209,6 +218,7 @@ Column {
       }
 
       Button {
+        width: (editorActions.width - editorActions.spacing) / 2
         text: "Cancel"
         foreground: root.textColor
         bordered: false

--- a/components/SubscriptionSection.qml
+++ b/components/SubscriptionSection.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls as QQC
 import qs.Commons
 import qs.Ui
 import "../Model.js" as Model
@@ -22,6 +23,7 @@ Column {
 
   signal urlCommitted(string url)
   signal updateRequested()
+  signal backRequested()
 
   readonly property string url: service.config.remoteConfigUrl
   readonly property bool updating: service.actionKind === "update" || service.actionKind === "init"
@@ -48,13 +50,26 @@ Column {
     width: parent.width
     implicitHeight: Math.max(sectionHeader.implicitHeight, updatedLabel.implicitHeight)
 
-    PanelSectionHeader {
+    Row {
       id: sectionHeader
       anchors.left: parent.left
       anchors.verticalCenter: parent.verticalCenter
-      text: "SUBSCRIPTION"
-      foreground: root.textColor
-      fontFamily: root.panelFontFamily
+      spacing: Style.space(8)
+
+      Button {
+        text: "←"
+        foreground: root.textColor
+        bordered: false
+        fontSize: Style.font.title
+        onClicked: root.backRequested()
+      }
+
+      PanelSectionHeader {
+        anchors.verticalCenter: parent.verticalCenter
+        text: "SUBSCRIPTION"
+        foreground: root.textColor
+        fontFamily: root.panelFontFamily
+      }
     }
 
     Text {
@@ -70,32 +85,30 @@ Column {
   }
 
   // ---- read-only view
-  CursorSurface {
+  QQC.TextField {
+    id: urlDisplay
     visible: !root.editing
     width: parent.width
-    implicitHeight: urlText.implicitHeight + Style.spacing.rowPaddingX
-    foreground: root.textColor
-    hasCursor: root.cursorTarget === "url"
-
-    Text {
-      id: urlText
-      anchors.left: parent.left
-      anchors.right: parent.right
-      anchors.verticalCenter: parent.verticalCenter
-      anchors.leftMargin: Style.space(10)
-      anchors.rightMargin: Style.space(10)
-      text: Model.displayUrl(root.url, root.revealed)
-      color: root.url === ""
-        ? Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
-        : root.textColor
-      font.family: root.panelFontFamily
-      font.pixelSize: Style.font.bodySmall
-      wrapMode: Text.WrapAnywhere
-      maximumLineCount: 2
-      elide: Text.ElideRight
+    implicitHeight: Style.space(40)
+    readOnly: true
+    focusPolicy: Qt.NoFocus
+    selectByMouse: false
+    text: Model.displayUrl(root.url, root.revealed)
+    color: root.url === ""
+      ? Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
+      : root.textColor
+    font.family: root.panelFontFamily
+    font.pixelSize: Style.font.bodySmall
+    leftPadding: Style.space(10)
+    rightPadding: Style.space(10)
+    topPadding: Style.space(8)
+    bottomPadding: Style.space(8)
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.04)
+      border.width: 1
+      border.color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.16)
     }
-
-    TapHandler { onTapped: root.beginEdit() }
   }
 
   Row {
@@ -104,7 +117,7 @@ Column {
     spacing: Style.spacing.controlGap
 
     Button {
-      text: root.updating ? "Fetching…" : "Update now"
+      text: root.updating ? "Updating…" : "Update"
       foreground: root.textColor
       bordered: true
       enabled: root.url !== "" && !root.service.busy
@@ -114,10 +127,11 @@ Column {
     }
 
     Button {
-      text: root.url === "" ? "Add URL" : "Change URL"
+      text: root.url === "" ? "Add" : "Edit"
       foreground: root.textColor
       bordered: true
       enabled: !root.service.busy
+      hasCursor: root.cursorTarget === "edit"
       fontSize: Style.font.bodySmall
       onClicked: root.beginEdit()
     }
@@ -138,12 +152,32 @@ Column {
     width: parent.width
     spacing: Style.space(8)
 
-    TextField {
+    QQC.TextArea {
       id: field
       width: parent.width
-      foreground: root.textColor
+      implicitHeight: Math.max(Style.space(74), contentHeight + topPadding + bottomPadding)
+      color: root.textColor
+      selectionColor: Color.accent
+      selectedTextColor: root.textColor
+      placeholderTextColor: Qt.darker(root.textColor, 1.6)
       placeholderText: "https://example.com/subscription"
-      onAccepted: root.commit()
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.body
+      wrapMode: TextEdit.WrapAnywhere
+      selectByMouse: true
+      leftPadding: Style.spacing.controlPaddingX
+      rightPadding: Style.spacing.controlPaddingX
+      topPadding: Style.spacing.inputPaddingY
+      bottomPadding: Style.spacing.inputPaddingY
+      background: Rectangle {
+        radius: Style.cornerRadius
+        color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b,
+          field.activeFocus ? 0.09 : 0.04)
+        border.width: field.activeFocus ? 2 : 1
+        border.color: field.activeFocus
+          ? Color.accent
+          : Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.24)
+      }
       Keys.onPressed: function(event) {
         if (event.key === Qt.Key_Escape) {
           root.cancelEdit()
@@ -166,7 +200,7 @@ Column {
       spacing: Style.spacing.controlGap
 
       Button {
-        text: root.service.probe.configPresent ? "Save and fetch" : "Save and set up"
+        text: root.service.probe.configPresent ? "Update" : "Save and set up"
         foreground: root.textColor
         bordered: true
         enabled: Model.subscriptionUrlError(field.text) === "" && !root.service.busy

--- a/install.sh
+++ b/install.sh
@@ -62,14 +62,14 @@ else
   ln -s "$project_dir" "$install_path"
 fi
 
-if command -v omarchy-shell >/dev/null 2>&1; then
-  omarchy-shell shell rescanPlugins >/dev/null 2>&1 || true
-  omarchy plugin enable "$plugin_id" >/dev/null 2>&1 || true
+if $restart_shell; then
+  printf '%s\n' 'Restarting Omarchy shell…'
+  omarchy restart shell
 fi
 
-if $restart_shell; then
-  omarchy restart shell >/dev/null 2>&1 || true
-fi
+printf '%s\n' 'Registering Mihoro in the bar…'
+omarchy-shell shell rescanPlugins
+omarchy plugin enable "$plugin_id"
 
 printf 'Mihoro installed for development at %s\n' "$install_path"
 printf '%s\n' 'Open the panel from the bar. QML edits are read through the symlink.'

--- a/tests/test_clash_api.js
+++ b/tests/test_clash_api.js
@@ -103,6 +103,7 @@ const configs = api.parseConfigs(JSON.stringify({
   "socks-port": 7892,
   "mixed-port": 7890,
   "allow-lan": true,
+  tun: { enable: true },
   mode: "Global",
   "log-level": "info"
 }))
@@ -111,6 +112,9 @@ assert.strictEqual(configs.mixedPort, 7890)
 assert.strictEqual(configs.port, 7891)
 assert.strictEqual(configs.socksPort, 7892)
 assert.strictEqual(configs.allowLan, true)
+assert.strictEqual(configs.tunEnabled, true)
+assert.strictEqual(api.parseConfigs('{"tun":{"enable":false}}').tunEnabled, false)
+assert.strictEqual(api.parseConfigs('{"mode":"rule"}').tunEnabled, null)
 assert.strictEqual(api.parseConfigs("["), null)
 
 const conns = api.parseConnections(JSON.stringify({

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -54,3 +54,49 @@ grep -Fq 'plugin-backups' install.sh
 }
 
 echo "install tests passed"
+
+# A failed shell registration must not be reported as a successful install.
+# The plugin files alone cannot produce a bar icon; enable is the operation
+# that adds the widget to the user's bar layout.
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+mkdir -p "$test_root/bin" "$test_root/config"
+
+cat >"$test_root/bin/omarchy" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "plugin validate" ]]; then
+  exit 0
+elif [[ "$1 $2" == "plugin enable" ]]; then
+  printf '%s\n' 'simulated enable failure' >&2
+  exit 1
+elif [[ "$1 $2" == "restart shell" ]]; then
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$test_root/bin/omarchy"
+
+cat >"$test_root/bin/omarchy-shell" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$test_root/bin/omarchy-shell"
+
+if output="$(PATH="$test_root/bin:/usr/bin:/bin" \
+  XDG_CONFIG_HOME="$test_root/config" \
+  HOME="$test_root/home" \
+  ./install.sh 2>&1)"; then
+  echo "install.sh reported success when plugin enable failed" >&2
+  exit 1
+fi
+
+[[ "$output" == *"simulated enable failure"* ]] || {
+  echo "install.sh hid the plugin enable error" >&2
+  exit 1
+}
+[[ "$output" != *"Mihoro installed"* ]] || {
+  echo "install.sh printed its success message after plugin enable failed" >&2
+  exit 1
+}
+
+echo "install failure handling tests passed"

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -14,6 +14,7 @@ assert.deepStrictEqual(Array.from(model.applyCommand()), ["mihoro", "apply"])
 assert.deepStrictEqual(Array.from(model.startCommand()), ["mihoro", "start"])
 assert.deepStrictEqual(Array.from(model.stopCommand()), ["mihoro", "stop"])
 assert.deepStrictEqual(Array.from(model.restartCommand()), ["mihoro", "restart"])
+assert.deepStrictEqual(Array.from(model.proxyExportCommand()), ["mihoro", "proxy", "export"])
 
 for (const forbidden of ["uninstall", "upgrade", "install.sh", "curl -fsSL"])
   assert.ok(!JSON.stringify(model.PROBE_SCRIPT).includes(forbidden),
@@ -155,14 +156,16 @@ assert.strictEqual(model.isValidSubscriptionUrl("nope"), false)
 // The token is the credential, so it is hidden whole rather than partially —
 // half a token is still half a token to anyone reading over a shoulder.
 const masked = model.maskUrl("https://sub.example.com/link/AbCdEf123456789?clash=1&token=supersecretvalue")
-assert.ok(masked.startsWith("https://sub.example.com/link/"))
+assert.strictEqual(masked, "https://sub.example.com/*******")
 assert.ok(!masked.includes("AbCdEf123456789"))
 assert.ok(!masked.includes("supersecretvalue"))
-assert.ok(masked.includes("clash=1"), "short, non-secret parameters stay readable")
-assert.ok(masked.includes("token="), "the parameter name still shows what was hidden")
+assert.strictEqual(
+  model.maskUrl("https://panel.example.com/users/api/s/abcdefghijklmnop?token=supersecretvalue"),
+  "https://panel.example.com/*******")
 
-// A short path is not a token and stays legible.
-assert.strictEqual(model.maskUrl("https://example.com/sub"), "https://example.com/sub")
+// Even short paths can identify an account or endpoint, so the entire tail is
+// hidden. Only the origin remains useful for recognizing the provider.
+assert.strictEqual(model.maskUrl("https://example.com/sub"), "https://example.com/*******")
 assert.strictEqual(model.maskUrl(""), "")
 
 assert.strictEqual(model.displayUrl("", false), "No subscription URL yet")

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -45,6 +45,20 @@ grep -Fq 'mihoro.connection.label' Panel.qml
 ! grep -rFq 'mihoro.state' Panel.qml
 ! grep -rEq '\broot\.state\b' Service.qml
 
+# Live traffic is presented as two centered, equally sized metrics with stable
+# semantic colours: green for download and red for upload.
+grep -Fq 'label: "DOWNLOAD"' components/ConnectionSection.qml
+grep -Fq 'label: "UPLOAD"' components/ConnectionSection.qml
+grep -Fq 'metricColor: Color.accent' components/ConnectionSection.qml
+grep -Fq 'metricColor: Color.urgent' components/ConnectionSection.qml
+grep -Fq 'horizontalAlignment: Text.AlignHCenter' components/ConnectionSection.qml
+grep -Fq 'component Speed: Item {' components/ConnectionSection.qml
+grep -Fq 'color: root.textColor' components/ConnectionSection.qml
+! grep -Fq 'color: Qt.rgba(metricColor.r' components/ConnectionSection.qml
+! grep -Eq '#[0-9a-fA-F]{6}' components/ConnectionSection.qml
+grep -Fq 'label: "TUN"' components/ConnectionSection.qml
+grep -Fq 'root.service.liveConfigs.tunEnabled' components/ConnectionSection.qml
+
 # ---- subscriptions --------------------------------------------------------
 
 # URL subscriptions only: one remote config URL, fetched by the CLI.
@@ -75,6 +89,47 @@ grep -Fq 'ConnectionSection {' Panel.qml
 grep -Fq 'SubscriptionSection {' Panel.qml
 grep -Fq 'SetupCard {' Panel.qml
 grep -Fq 'blocked: subscription.editing' Panel.qml
+grep -Fq 'iconSize: Style.space(12)' Panel.qml
+grep -Fq 'onCopyProxyRequested: mihoro.copyProxyExport()' Panel.qml
+grep -Fq 'text: "Copy proxy export"' components/PanelMenu.qml
+grep -Fq 'https://github.com/huacnlee/omarchy-mihoro' components/PanelMenu.qml
+grep -Fq 'Model.proxyExportCommand()' Service.qml
+grep -Fq 'clipboardProcess.write(root._pendingClipboard)' Service.qml
+grep -Fq 'command: ["wl-copy"]' Service.qml
+
+# The popup is two internal pages, and every fresh open returns to the main
+# controls. Subscription navigation is explicit rather than a collapsible
+# section or an accidental click on the credential display.
+grep -Fq 'property int panelPage: 1' Panel.qml
+grep -Fq 'panelPage = 1' Panel.qml
+grep -Fq 'subscription.cancelEdit()' Panel.qml
+grep -Fq 'visible: root.panelPage === 1' Panel.qml
+grep -Fq 'visible: root.panelPage === 2' Panel.qml
+grep -Fq 'onSubscriptionRequested: root.openSubscriptionPage()' Panel.qml
+grep -Fq 'SettingsIcon {' components/ModeSection.qml
+grep -Fq 'PanelActionButton {' components/ModeSection.qml
+grep -Fq 'id: modeControlRow' components/ModeSection.qml
+grep -Fq 'width: modeControlRow.width - subscriptionButton.width - modeControlRow.spacing' components/ModeSection.qml
+! grep -Fq 'text: "⚙"' components/ModeSection.qml
+grep -Fq 'onBackRequested: root.leaveSubscriptionPage()' Panel.qml
+grep -Fq 'if (root.panelPage === 2) root.leaveSubscriptionPage()' Panel.qml
+
+# Page two owns subscription editing. The displayed URL itself is deliberately
+# inert; only the named Edit/Add action opens the field.
+grep -Fq 'text: "SUBSCRIPTION"' components/SubscriptionSection.qml
+grep -Fq 'text: root.url === "" ? "Add" : "Edit"' components/SubscriptionSection.qml
+grep -Fq 'text: root.updating ? "Updating…" : "Update"' components/SubscriptionSection.qml
+grep -Fq 'text: root.service.probe.configPresent ? "Update" : "Save and set up"' components/SubscriptionSection.qml
+grep -Fq 'text: root.revealed ? "Hide" : "Show"' components/SubscriptionSection.qml
+grep -Fq 'QQC.TextArea {' components/SubscriptionSection.qml
+grep -Fq 'QQC.TextField {' components/SubscriptionSection.qml
+grep -Fq 'wrapMode: TextEdit.WrapAnywhere' components/SubscriptionSection.qml
+grep -Fq 'readOnly: true' components/SubscriptionSection.qml
+grep -Fq 'focusPolicy: Qt.NoFocus' components/SubscriptionSection.qml
+grep -Fq 'text: Model.displayUrl(root.url, root.revealed)' components/SubscriptionSection.qml
+! sed -n '/id: urlDisplay/,/\/\/ ---- editor/p' components/SubscriptionSection.qml | grep -Fq 'wrapMode:'
+! sed -n '/\/\/ ---- editor/,$p' components/SubscriptionSection.qml | grep -Fq 'TextField {'
+! sed -n '/id: urlDisplay/,/^  }/p' components/SubscriptionSection.qml | grep -Fq 'TapHandler'
 
 # Keyboard: toggle, refresh, update, edit, and the three modes by number.
 grep -Fq 'key === "t"' Panel.qml
@@ -127,6 +182,7 @@ PY
 # anywhere but back into mihoro.toml.
 ! grep -rEq 'console\.(log|warn|error).*(secret|remoteConfigUrl|remote_config_url)' \
   Panel.qml Service.qml components/*.qml Model.js ClashApi.js MihoroConfig.js
-! grep -rFq 'wl-copy' Panel.qml Service.qml components/*.qml
+# Clipboard data is written over stdin, never embedded in a command argument.
+! grep -rEq 'execDetached\(.*wl-copy|bash.*wl-copy' Panel.qml Service.qml components/*.qml
 
 echo "panel source tests passed"

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -68,9 +68,10 @@ grep -Fq 'remote_config_url' MihoroConfig.js
 # subscription the proxy is not using.
 grep -Fq 'writeConfig({ remoteConfigUrl: text }' Service.qml
 
-# Masked by default, with an explicit reveal.
-grep -Fq 'property bool revealed: false' components/SubscriptionSection.qml
-grep -Fq 'Model.displayUrl(root.url, root.revealed)' components/SubscriptionSection.qml
+# The credential is absent from read-only mode; it only enters a control after
+# the user explicitly chooses Edit/Add.
+! grep -Fq 'property bool revealed:' components/SubscriptionSection.qml
+! grep -Fq 'Model.displayUrl(' components/SubscriptionSection.qml
 
 # The write is atomic and keeps the file's permissions — it holds a credential.
 grep -Fq 'mktemp' MihoroConfig.js
@@ -114,22 +115,25 @@ grep -Fq 'width: modeControlRow.width - subscriptionButton.width - modeControlRo
 grep -Fq 'onBackRequested: root.leaveSubscriptionPage()' Panel.qml
 grep -Fq 'if (root.panelPage === 2) root.leaveSubscriptionPage()' Panel.qml
 
-# Page two owns subscription editing. The displayed URL itself is deliberately
-# inert; only the named Edit/Add action opens the field.
+# Page two owns subscription editing. Read-only mode never renders the URL;
+# only the named Edit/Add action opens the field.
 grep -Fq 'text: "SUBSCRIPTION"' components/SubscriptionSection.qml
 grep -Fq 'text: root.url === "" ? "Add" : "Edit"' components/SubscriptionSection.qml
 grep -Fq 'text: root.updating ? "Updating…" : "Update"' components/SubscriptionSection.qml
 grep -Fq 'text: root.service.probe.configPresent ? "Update" : "Save and set up"' components/SubscriptionSection.qml
-grep -Fq 'text: root.revealed ? "Hide" : "Show"' components/SubscriptionSection.qml
 grep -Fq 'QQC.TextArea {' components/SubscriptionSection.qml
-grep -Fq 'QQC.TextField {' components/SubscriptionSection.qml
 grep -Fq 'wrapMode: TextEdit.WrapAnywhere' components/SubscriptionSection.qml
-grep -Fq 'readOnly: true' components/SubscriptionSection.qml
-grep -Fq 'focusPolicy: Qt.NoFocus' components/SubscriptionSection.qml
-grep -Fq 'text: Model.displayUrl(root.url, root.revealed)' components/SubscriptionSection.qml
-! sed -n '/id: urlDisplay/,/\/\/ ---- editor/p' components/SubscriptionSection.qml | grep -Fq 'wrapMode:'
+! grep -Fq 'QQC.TextField {' components/SubscriptionSection.qml
+! grep -Fq 'text: "Show"' components/SubscriptionSection.qml
+! grep -Fq 'text: "Hide"' components/SubscriptionSection.qml
+grep -Fq 'text: "Last updated " + Model.formatAgo' components/SubscriptionSection.qml
+grep -Fq 'visible: !root.editing && root.service.probe.configPresent' components/SubscriptionSection.qml
+grep -Fq 'id: subscriptionStatus' components/SubscriptionSection.qml
+grep -Fq 'id: subscriptionActions' components/SubscriptionSection.qml
+grep -Fq 'width: (subscriptionActions.width - subscriptionActions.spacing) / 2' components/SubscriptionSection.qml
+grep -Fq 'text: "SUBSCRIPTION URL"' components/SubscriptionSection.qml
+grep -Fq 'id: editorActions' components/SubscriptionSection.qml
 ! sed -n '/\/\/ ---- editor/,$p' components/SubscriptionSection.qml | grep -Fq 'TextField {'
-! sed -n '/id: urlDisplay/,/^  }/p' components/SubscriptionSection.qml | grep -Fq 'TapHandler'
 
 # Keyboard: toggle, refresh, update, edit, and the three modes by number.
 grep -Fq 'key === "t"' Panel.qml


### PR DESCRIPTION
## Summary

- fix development plugin registration and installation failure handling
- add a dedicated subscription-management page with private URL masking and keyboard navigation
- improve live connection metrics, expose TUN state, and add proxy-export copying
- align controls and icons with Omarchy styling and theme colors
- document installation, initialization, TUN setup, verification, and add a panel preview

## Impact

Mihoro users get a clearer status panel and a separate, safer subscription workflow. Plugin setup is more reliable, proxy environment information can be copied from the menu without placing it in command arguments or logs, and the README now covers first-time setup.

## Validation

- `make test`
- `make qml-check`
- `git diff --check`
