### PR TITLE
Improve global mode selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Project working agreements
+
+## UI colors
+
+- Use Omarchy system/theme colors from `qs.Commons.Color` and shared `Style` helpers.
+- Do not hard-code hex, RGB, or named display colors in QML components.
+- Derived shades may use `Qt.darker`, `Qt.lighter`, or `Qt.rgba` with a system color as their source.
+- Reusable controls must accept or inherit the relevant foreground/accent colors so they remain correct across themes.
+
+## Verification
+
+- Run `make validate` after QML or behavior changes.

--- a/ClashApi.js
+++ b/ClashApi.js
@@ -81,6 +81,7 @@ function getCommand(base, secret, path) {
 function versionCommand(base, secret) { return getCommand(base, secret, "/version") }
 function configsCommand(base, secret) { return getCommand(base, secret, "/configs") }
 function connectionsCommand(base, secret) { return getCommand(base, secret, "/connections") }
+function proxiesCommand(base, secret) { return getCommand(base, secret, "/proxies") }
 
 function setModeCommand(base, secret, mode) {
   return ["curl", "-sS", "--max-time", TIMEOUT_SECONDS, "-w", "\\n%{http_code}",
@@ -88,6 +89,14 @@ function setModeCommand(base, secret, mode) {
           "-d", JSON.stringify({ mode: normalizeMode(mode) || "rule" })]
     .concat(authArgs(secret))
     .concat([String(base) + "/configs"])
+}
+
+function selectProxyCommand(base, secret, group, name) {
+  return ["curl", "-sS", "--max-time", TIMEOUT_SECONDS, "-w", "\\n%{http_code}",
+          "-X", "PUT", "-H", "Content-Type: application/json",
+          "-d", JSON.stringify({ name: String(name || "") })]
+    .concat(authArgs(secret))
+    .concat([String(base) + "/proxies/" + encodeURIComponent(String(group || ""))])
 }
 
 // `/traffic` pushes one JSON object per second for as long as the socket is
@@ -187,6 +196,20 @@ function parseConnections(body) {
     uploadTotal: Number(payload.uploadTotal) || 0,
     memory: Number(payload.memory) || 0
   }
+}
+
+function parseGlobalProxies(body) {
+  var payload = parseJson(body)
+  if (!payload) return null
+  var proxies = payload.proxies
+  var group = proxies && typeof proxies === "object" ? proxies.GLOBAL : null
+  var all = group && group.all instanceof Array ? group.all : []
+  var options = []
+  for (var i = 0; i < all.length; i++) {
+    var name = String(all[i] || "")
+    if (name !== "") options.push({ value: name, label: name })
+  }
+  return { current: group ? String(group.now || "") : "", options: options }
 }
 
 function parseTrafficLine(line) {

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ QMLLINT := /usr/lib/qt6/bin/qmllint
 QML_FILES := Panel.qml Service.qml \
 	components/MihoroIcon.qml \
 	components/SettingsIcon.qml \
+	components/ServiceSwitch.qml \
 	components/StatRow.qml \
 	components/ModeSection.qml \
 	components/ConnectionSection.qml \

--- a/Model.js
+++ b/Model.js
@@ -21,6 +21,13 @@ function modeIndex(value) {
   return 0
 }
 
+function modeSelectionAction(next, current) {
+  var wanted = String(next || "").toLowerCase()
+  if (modeIndex(wanted) >= MODES.length || MODES[modeIndex(wanted)].value !== wanted) return "none"
+  if (wanted === "global") return "choose_proxy"
+  return wanted === String(current || "").toLowerCase() ? "none" : "switch"
+}
+
 // ------------------------------------------------------------------ the CLI
 //
 // mihoro is installed by the user, not by this plugin: it owns the mihomo

--- a/Panel.qml
+++ b/Panel.qml
@@ -73,7 +73,7 @@ Panel {
     clampCursor()
     var target = cursorTarget
     if (target === "power") mihoro.toggleService()
-    else if (target === "mode") mihoro.setMode(Model.MODES[modeCursor].value)
+    else if (target === "mode") root.requestMode(Model.MODES[modeCursor].value)
     else if (target === "subscription") root.openSubscriptionPage()
     else if (target === "edit") subscription.beginEdit()
     else if (target === "update") mihoro.updateSubscription()
@@ -83,6 +83,18 @@ Panel {
         root.openSubscriptionPage()
         subscription.beginEdit()
       }
+    }
+  }
+
+  function requestMode(value) {
+    var action = Model.modeSelectionAction(value, mihoro.mode)
+    if (action === "choose_proxy") {
+      modeSection.selectingGlobal = true
+      mihoro.refreshProxies()
+    } else {
+      modeSection.selectingGlobal = false
+      mihoro.cancelGlobalSelection()
+      if (action === "switch") mihoro.setMode(value)
     }
   }
 
@@ -105,8 +117,9 @@ Panel {
 
   function cycleMode(delta) {
     if (!mihoro.canSwitchMode) return
-    var next = (Model.modeIndex(mihoro.mode) + delta + Model.MODES.length) % Model.MODES.length
-    mihoro.setMode(Model.MODES[next].value)
+    var current = modeSection.selectingGlobal ? Model.modeIndex("global") : Model.modeIndex(mihoro.mode)
+    var next = (current + delta + Model.MODES.length) % Model.MODES.length
+    root.requestMode(Model.MODES[next].value)
   }
 
   Service {
@@ -230,9 +243,9 @@ Panel {
         else if (root.panelPage === 1 && key === "r") mihoro.refresh()
         else if (root.panelPage === 1 && key === "s") root.openSubscriptionPage()
         else if (root.panelPage === 1 && key === "m") root.cycleMode(1)
-        else if (root.panelPage === 1 && key === "1") mihoro.setMode("rule")
-        else if (root.panelPage === 1 && key === "2") mihoro.setMode("global")
-        else if (root.panelPage === 1 && key === "3") mihoro.setMode("direct")
+        else if (root.panelPage === 1 && key === "1") root.requestMode("rule")
+        else if (root.panelPage === 1 && key === "2") root.requestMode("global")
+        else if (root.panelPage === 1 && key === "3") root.requestMode("direct")
       }
 
       Flickable {
@@ -288,7 +301,7 @@ Panel {
               anchors.verticalCenter: parent.verticalCenter
               spacing: Style.space(6)
 
-              ToggleSwitch {
+              ServiceSwitch {
                 id: powerSwitch
                 anchors.verticalCenter: parent.verticalCenter
                 visible: mihoro.initialized
@@ -356,6 +369,7 @@ Panel {
           }
 
           ModeSection {
+            id: modeSection
             visible: root.panelPage === 1 && mihoro.initialized
             width: parent.width
             textColor: root.foreground
@@ -365,10 +379,18 @@ Panel {
             pending: mihoro.pendingMode !== ""
             hint: mihoro.modeHint
             cursorIndex: root.cursorTarget === "mode" ? root.modeCursor : -1
-            onModeRequested: function(value) { mihoro.setMode(value) }
+            proxyOptions: mihoro.globalProxyOptions
+            currentProxy: mihoro.pendingGlobalProxy !== "" ? mihoro.pendingGlobalProxy : mihoro.currentGlobalProxy
+            onModeRequested: function(value) { root.requestMode(value) }
+            onGlobalRequested: mihoro.refreshProxies()
+            onProxyRequested: function(value) { mihoro.selectGlobalProxy(value) }
             onSubscriptionRequested: root.openSubscriptionPage()
             onChipHovered: function(index, isHovered) {
-              if (!isHovered || !mihoro.canSwitchMode) return
+              if (!isHovered) {
+                if (root.cursorTarget === "mode") root.cursorActive = false
+                return
+              }
+              if (!mihoro.canSwitchMode) return
               root.cursorActive = true
               root.cursorIndex = root.targets.indexOf("mode")
               root.modeCursor = index

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An Omarchy bar panel for [mihoro](https://github.com/spencerwooo/mihoro), the
 Mihomo CLI client for Linux.
 
-<img width="400" alt="Mihoro panel" src="https://github.com/user-attachments/assets/ca5a27d9-a05e-4134-8cae-360ddef861d8" />
+<img width="400" alt="Mihoro panel" src="https://github.com/user-attachments/assets/828033d7-930b-4e66-8a7a-8d968240b8c3" />
 
 Use it to monitor your proxy, switch between Rule, Global, and Direct modes,
 and manage your subscription.

--- a/Service.qml
+++ b/Service.qml
@@ -37,6 +37,8 @@ Item {
   property real uploadTotal: 0
   property real upSpeed: 0
   property real downSpeed: 0
+  property var globalProxyOptions: []
+  property string currentGlobalProxy: ""
 
   // ---- in-flight intent
   //
@@ -45,6 +47,8 @@ Item {
   // real state. Waiting for systemd makes the panel feel broken.
   property int desiredActive: -1
   property string pendingMode: ""
+  property string pendingGlobalProxy: ""
+  property bool globalSelectionRequested: false
   property string actionKind: ""
   property string actionStatus: ""
   property string lastError: ""
@@ -75,7 +79,8 @@ Item {
     : (liveConfigs && liveConfigs.mode !== "" ? liveConfigs.mode : config.mode)
 
   readonly property bool busy: probeProcess.running || configReadProcess.running
-    || actionProcess.running || modeProcess.running || configWriteProcess.running
+    || actionProcess.running || modeProcess.running || proxySelectProcess.running
+    || configWriteProcess.running
   readonly property bool actionRunning: actionProcess.running
   readonly property bool copyingProxyExport: proxyExportProcess.running || clipboardProcess.running
 
@@ -115,6 +120,13 @@ Item {
       configsProcess.command = ClashApi.configsCommand(apiBase, config.secret)
       configsProcess.running = true
     }
+    refreshProxies()
+  }
+
+  function refreshProxies() {
+    if (apiBase === "" || !serviceActive || proxiesProcess.running) return
+    proxiesProcess.command = ClashApi.proxiesCommand(apiBase, config.secret)
+    proxiesProcess.running = true
   }
 
   function refreshConnections() {
@@ -138,6 +150,21 @@ Item {
     // with the core; if it does not, the file is what `mihoro apply` reads.
     // A write that could not start takes the optimistic chip back with it.
     if (!writeConfig({ mode: wanted }, apiBase === "" ? "apply" : "mode")) pendingMode = ""
+  }
+
+  function selectGlobalProxy(name) {
+    var wanted = String(name || "")
+    if (wanted === "" || !canSwitchMode || proxySelectProcess.running) return
+    pendingGlobalProxy = wanted
+    globalSelectionRequested = true
+    lastError = ""
+    proxySelectProcess.command = ClashApi.selectProxyCommand(apiBase, config.secret, "GLOBAL", wanted)
+    proxySelectProcess.running = true
+  }
+
+  function cancelGlobalSelection() {
+    globalSelectionRequested = false
+    pendingGlobalProxy = ""
   }
 
   function toggleService() {
@@ -336,6 +363,7 @@ Item {
       if (versionProcess.running) versionProcess.running = false
       if (configsProcess.running) configsProcess.running = false
       if (connectionsProcess.running) connectionsProcess.running = false
+      if (proxiesProcess.running) proxiesProcess.running = false
     }
   }
 
@@ -421,6 +449,51 @@ Item {
       root.connectionCount = parsed.count
       root.downloadTotal = parsed.downloadTotal
       root.uploadTotal = parsed.uploadTotal
+    }
+  }
+
+  Process {
+    id: proxiesProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: proxiesOut; waitForEnd: true }
+    stderr: StdioCollector { id: proxiesErr; waitForEnd: true }
+    onExited: function(exitCode) {
+      var result = ClashApi.classify(exitCode, proxiesOut.text, proxiesErr.text)
+      if (!result.ok) return
+      var parsed = ClashApi.parseGlobalProxies(result.body)
+      if (!parsed) return
+      root.globalProxyOptions = parsed.options
+      root.currentGlobalProxy = parsed.current
+    }
+  }
+
+  Process {
+    id: proxySelectProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: proxySelectOut; waitForEnd: true }
+    stderr: StdioCollector { id: proxySelectErr; waitForEnd: true }
+    onExited: function(exitCode) {
+      var result = ClashApi.classify(exitCode, proxySelectOut.text, proxySelectErr.text)
+      if (!result.ok) {
+        root.cancelGlobalSelection()
+        root.lastError = result.message
+        return
+      }
+      var selected = root.pendingGlobalProxy
+      var activateGlobal = root.globalSelectionRequested
+      if (selected !== "") root.currentGlobalProxy = selected
+      root.pendingGlobalProxy = ""
+      root.globalSelectionRequested = false
+      if (activateGlobal && root.mode !== "global") root.setMode("global")
+      else {
+        if (activateGlobal) {
+          root.actionStatus = "Global connection selected."
+          actionStatusTimer.restart()
+        }
+      }
+      root.refreshProxies()
     }
   }
 

--- a/components/ModeSection.qml
+++ b/components/ModeSection.qml
@@ -20,8 +20,13 @@ Column {
   property bool pending: false
   property string hint: ""
   property int cursorIndex: -1
+  property var proxyOptions: []
+  property string currentProxy: ""
+  property bool selectingGlobal: false
 
   signal modeRequested(string value)
+  signal globalRequested()
+  signal proxyRequested(string value)
   signal chipHovered(int index, bool isHovered)
   signal subscriptionRequested()
 
@@ -61,24 +66,72 @@ Column {
     width: parent.width
     spacing: Style.space(6)
 
-    ButtonGroup {
+    Row {
       id: group
       anchors.verticalCenter: parent.verticalCenter
       width: modeControlRow.width - subscriptionButton.width - modeControlRow.spacing
-      options: root.options
-      value: root.mode
-      foreground: root.textColor
-      accent: root.accentColor
-      fontFamily: root.panelFontFamily
-      fontSize: Style.font.bodySmall
-      // The panel drives the cursor; Tab focus would give the group a second,
-      // competing highlight inside a surface that already has one.
-      focusable: false
-      cursorIndex: root.cursorIndex
+      spacing: Style.space(6)
       opacity: root.switchable ? 1.0 : 0.45
       enabled: root.switchable
-      onChanged: function(value) { if (root.switchable) root.modeRequested(value) }
-      onHovered: function(index, isHovered) { root.chipHovered(index, isHovered) }
+
+      Repeater {
+        model: root.options
+
+        delegate: Rectangle {
+          id: chip
+          required property var modelData
+          required property int index
+          readonly property bool selected: String(modelData.value) === root.mode
+          readonly property bool hot: chipHover.hovered || root.cursorIndex === index
+
+          width: chipLabel.implicitWidth + Style.space(28)
+          height: chipLabel.implicitHeight + Style.space(18)
+          radius: Style.cornerRadius
+          color: selected
+            ? Qt.rgba(root.accentColor.r, root.accentColor.g, root.accentColor.b, hot ? 0.32 : 0.22)
+            : (hot
+              ? Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.12)
+              : Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.035))
+          border.width: selected ? 2 : 1
+          border.color: selected
+            ? (hot ? Qt.lighter(root.accentColor, 1.22) : root.accentColor)
+            : Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, hot ? 0.55 : 0.22)
+
+          Behavior on color { ColorAnimation { duration: 90 } }
+
+          Text {
+            id: chipLabel
+            anchors.centerIn: parent
+            text: String(chip.modelData.label)
+            color: chip.selected
+              ? (chip.hot ? Qt.lighter(root.accentColor, 1.22) : root.accentColor)
+              : root.textColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.bodySmall
+            font.bold: chip.selected
+          }
+
+          HoverHandler {
+            id: chipHover
+            onHoveredChanged: root.chipHovered(chip.index, hovered)
+          }
+
+          MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+              var value = String(chip.modelData.value)
+              if (value === "global") {
+                root.selectingGlobal = true
+                root.globalRequested()
+              } else {
+                root.selectingGlobal = false
+                root.modeRequested(value)
+              }
+            }
+          }
+        }
+      }
     }
 
     PanelActionButton {
@@ -98,6 +151,20 @@ Column {
           : subscriptionButton.foreground
       }
     }
+  }
+
+  SearchableDropdown {
+    width: parent.width
+    visible: root.selectingGlobal || root.mode === "global"
+    label: "GLOBAL CONNECTION"
+    value: root.currentProxy
+    options: root.proxyOptions
+    placeholderText: root.proxyOptions.length > 0 ? "Choose a connection…" : "No connections available"
+    emptyText: "No connections available"
+    foreground: root.textColor
+    accent: root.accentColor
+    fontFamily: root.panelFontFamily
+    onChanged: function(value) { root.proxyRequested(value) }
   }
 
   Text {

--- a/components/ServiceSwitch.qml
+++ b/components/ServiceSwitch.qml
@@ -1,0 +1,73 @@
+import QtQuick
+import qs.Commons
+
+// The service switch uses semantic status colors rather than the shell's
+// theme-selected fill. ToggleSwitch intentionally resolves its track through
+// theme tokens, which can stay gray even when a caller supplies a green
+// accent; this compact variant makes the running/stopped state unambiguous.
+Item {
+  id: root
+
+  property bool checked: false
+  property bool busy: false
+  property bool hasCursor: false
+  property color foreground: Color.foreground
+  property color onColor: Color.accent
+  property color offColor: Qt.darker(foreground, 1.6)
+
+  signal toggled()
+  signal hovered(bool isHovered)
+
+  readonly property alias containsMouse: mouse.containsMouse
+  readonly property int trackHeight: Math.max(22, Math.round(Style.spacing.controlHeight * 0.55))
+  readonly property int trackWidth: Math.round(trackHeight * 1.9)
+  readonly property int knobSize: Math.max(6, Math.round(trackHeight * 0.72))
+  readonly property int knobInset: Math.max(1, Math.round((trackHeight - knobSize) / 2))
+  readonly property int cursorPad: Style.space(6)
+
+  implicitWidth: trackWidth + cursorPad * 2
+  implicitHeight: trackHeight + cursorPad * 2
+
+  Rectangle {
+    anchors.fill: parent
+    visible: root.hasCursor || mouse.containsMouse
+    color: "transparent"
+    radius: Style.cornerRadius
+    border.width: 1
+    border.color: root.checked ? root.onColor : root.offColor
+  }
+
+  Rectangle {
+    id: track
+    width: root.trackWidth
+    height: root.trackHeight
+    anchors.centerIn: parent
+    radius: Style.cornerRadius > 0 ? height / 2 : 0
+    color: root.checked ? root.onColor : root.offColor
+    border.width: 1
+    border.color: Qt.darker(color, 1.2)
+
+    Behavior on color { ColorAnimation { duration: 120 } }
+
+    Rectangle {
+      width: root.knobSize
+      height: root.knobSize
+      radius: Style.cornerRadius > 0 ? height / 2 : 0
+      anchors.verticalCenter: parent.verticalCenter
+      x: root.checked ? track.width - width - root.knobInset : root.knobInset
+      color: root.checked ? Color.background : Qt.lighter(root.offColor, 1.7)
+
+      Behavior on x { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+      Behavior on color { ColorAnimation { duration: 120 } }
+    }
+  }
+
+  MouseArea {
+    id: mouse
+    anchors.fill: parent
+    hoverEnabled: true
+    cursorShape: Qt.PointingHandCursor
+    onContainsMouseChanged: root.hovered(containsMouse)
+    onClicked: if (!root.busy) root.toggled()
+  }
+}

--- a/tests/test_clash_api.js
+++ b/tests/test_clash_api.js
@@ -44,6 +44,15 @@ assert.strictEqual(authed[authed.length - 1], "http://127.0.0.1:9090/configs")
 const connections = api.connectionsCommand("http://127.0.0.1:9090", "")
 assert.strictEqual(connections[connections.length - 1], "http://127.0.0.1:9090/connections")
 
+const proxies = api.proxiesCommand("http://127.0.0.1:9090", "s3cret")
+assert.ok(proxies.includes("Authorization: Bearer s3cret"))
+assert.strictEqual(proxies[proxies.length - 1], "http://127.0.0.1:9090/proxies")
+
+const selectGlobal = api.selectProxyCommand("http://127.0.0.1:9090", "s3cret", "GLOBAL", "Tokyo JP")
+assert.ok(selectGlobal.includes("PUT"))
+assert.ok(selectGlobal.includes('{"name":"Tokyo JP"}'))
+assert.strictEqual(selectGlobal[selectGlobal.length - 1], "http://127.0.0.1:9090/proxies/GLOBAL")
+
 const setMode = api.setModeCommand("http://127.0.0.1:9090", "s3cret", "Global")
 assert.ok(setMode.includes("PATCH"))
 assert.ok(setMode.includes('{"mode":"global"}'), "mode is normalised before it is sent")
@@ -131,6 +140,19 @@ assert.strictEqual(conns.memory, 4096)
 // mihomo sends `connections: null` when there are none.
 assert.strictEqual(api.parseConnections('{"downloadTotal":1,"uploadTotal":2,"connections":null}').count, 0)
 assert.strictEqual(api.parseConnections("nope"), null)
+
+const global = api.parseGlobalProxies(JSON.stringify({
+  proxies: {
+    GLOBAL: { type: "Selector", now: "Tokyo JP", all: ["DIRECT", "Tokyo JP", "Singapore"] },
+    "Tokyo JP": { type: "Shadowsocks" }
+  }
+}))
+assert.strictEqual(global.current, "Tokyo JP")
+assert.strictEqual(global.options.length, 3)
+assert.strictEqual(global.options[0].value, "DIRECT")
+assert.strictEqual(global.options[2].label, "Singapore")
+assert.strictEqual(api.parseGlobalProxies('{"proxies":{}}').options.length, 0)
+assert.strictEqual(api.parseGlobalProxies("nope"), null)
 
 const sample = api.parseTrafficLine('{"up":120,"down":4096}')
 assert.strictEqual(sample.up, 120)

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -214,4 +214,12 @@ assert.strictEqual(model.modeIndex("direct"), 2)
 assert.strictEqual(model.modeIndex("nope"), 0)
 assert.strictEqual(model.MODES.length, 3)
 
+// Global needs a concrete outbound before it can be enabled; the other modes
+// are complete choices by themselves.
+assert.strictEqual(model.modeSelectionAction("global", "rule"), "choose_proxy")
+assert.strictEqual(model.modeSelectionAction("global", "global"), "choose_proxy")
+assert.strictEqual(model.modeSelectionAction("direct", "rule"), "switch")
+assert.strictEqual(model.modeSelectionAction("rule", "rule"), "none")
+assert.strictEqual(model.modeSelectionAction("sideways", "rule"), "none")
+
 console.log("model tests passed")

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -140,7 +140,11 @@ grep -Fq 'key === "t"' Panel.qml
 grep -Fq 'key === "r"' Panel.qml
 grep -Fq 'key === "u"' Panel.qml
 grep -Fq 'key === "e"' Panel.qml
-grep -Fq 'mihoro.setMode("global")' Panel.qml
+grep -Fq 'root.requestMode("global")' Panel.qml
+grep -Fq 'ServiceSwitch {' Panel.qml
+grep -Fq 'property color onColor: Color.accent' components/ServiceSwitch.qml
+grep -Fq 'property color offColor: Qt.darker(foreground, 1.6)' components/ServiceSwitch.qml
+! grep -Eq '#[0-9a-fA-F]{6}' components/ServiceSwitch.qml
 
 # IPC is how the rest of Omarchy drives the panel.
 grep -Fq 'function mode(value: string): string' Panel.qml


### PR DESCRIPTION
## What changed

- give Rule, Global, and Direct clearly distinct active, inactive, and hover states
- clear the panel cursor when the pointer leaves the mode tabs to prevent sticky hover styling
- load the mihomo `GLOBAL` selector choices and show them in a searchable connection picker
- switch to Global only after the chosen connection is accepted
- preserve latest-user-intent ordering when Rule or Direct is chosen during an in-flight Global selection
- keep keyboard shortcuts and mode cycling consistent with the pointer flow
- render the service switch blue when on and gray when off

## Why

The shared button cursor could remain active after a fast pointer exit, making hover styling appear stuck. Global mode also switched immediately without letting the user choose which outbound connection should carry all traffic.

## Impact

The selected mode is now visually unambiguous. Entering Global mode requires an explicit connection choice, while Rule and Direct remain immediate actions. The service switch also communicates its on/off state through blue and gray coloring.

## Validation

- `make validate`
- JavaScript model and Clash API tests
- QML name and panel source checks
- install tests
- Omarchy plugin validation
