### PR TITLE
Fix live speed accuracy and chart traffic history

### DIFF
--- a/ClashApi.js
+++ b/ClashApi.js
@@ -212,11 +212,80 @@ function parseGlobalProxies(body) {
   return { current: group ? String(group.now || "") : "", options: options }
 }
 
+// `Number(null)` is 0 and `Number("")` is 0, either of which would pass for a
+// counter that is simply absent. A missing field has to stay missing.
+function finiteNumber(value) {
+  if (value === undefined || value === null || value === "") return NaN
+  var parsed = Number(value)
+  return isFinite(parsed) ? parsed : NaN
+}
+
+// A `/traffic` message carries both a per-interval reading (`up`/`down`) and
+// the core's cumulative counters (`upTotal`/`downTotal`). Both are kept: the
+// totals are what the rate is actually derived from, and the per-interval
+// numbers are the fallback for cores old enough not to send totals.
 function parseTrafficLine(line) {
   var payload = parseJson(line)
   if (!payload) return null
   var up = Number(payload.up)
   var down = Number(payload.down)
   if (!isFinite(up) || !isFinite(down)) return null
-  return { up: up, down: down }
+  var upTotal = finiteNumber(payload.upTotal)
+  var downTotal = finiteNumber(payload.downTotal)
+  var hasTotals = isFinite(upTotal) && isFinite(downTotal)
+  return {
+    up: up,
+    down: down,
+    upTotal: hasTotals ? upTotal : 0,
+    downTotal: hasTotals ? downTotal : 0,
+    hasTotals: hasTotals
+  }
+}
+
+// Below this there is not enough wall clock for the division to mean anything.
+var MIN_RATE_INTERVAL_SECONDS = 0.2
+
+// Why the rate is not simply `up`/`down`:
+//
+// mihomo fills `up`/`down` from a snapshot buffer that its own one-second
+// ticker overwrites, but the stream is written by a *second* ticker started
+// when the socket opened. The two run at the same rate out of phase, so the
+// handler regularly emits one buffer twice and skips the next. Measured
+// against the totals in the very same messages, 59 of 60 consecutive samples
+// disagreed with the traffic that actually moved — the worst by 292x — even
+// though the sum over the minute was correct to within 0.01%. Totals are
+// exact and monotonic, so differencing them gives a reading that is right in
+// the second you are looking at it, not merely right on average.
+//
+// `anchor` is the last reading a rate was published from, not the previous
+// sample. When a sample arrives too soon after it to divide by, the anchor
+// stays put: those bytes remain counted and land in the next reading instead
+// of being divided by a near-zero interval into a spike.
+function trafficRate(anchor, sample, atSeconds) {
+  if (!sample) return null
+  var now = Number(atSeconds)
+  if (!isFinite(now) || now < 0) now = 0
+
+  // Nothing to difference. The core's own reading is all there is.
+  if (!sample.hasTotals)
+    return { rate: { up: sample.up, down: sample.down }, anchor: null }
+
+  var next = { up: sample.upTotal, down: sample.downTotal, at: now }
+
+  // No anchor yet, or the counters went backwards because the core restarted
+  // underneath the stream. Show what this message claims and start again here.
+  if (!anchor || sample.upTotal < anchor.up || sample.downTotal < anchor.down)
+    return { rate: { up: sample.up, down: sample.down }, anchor: next }
+
+  var elapsed = now - anchor.at
+  if (!(elapsed >= MIN_RATE_INTERVAL_SECONDS))
+    return { rate: null, anchor: anchor }
+
+  return {
+    rate: {
+      up: (sample.upTotal - anchor.up) / elapsed,
+      down: (sample.downTotal - anchor.down) / elapsed
+    },
+    anchor: next
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ QML_FILES := Panel.qml Service.qml \
 	components/SettingsIcon.qml \
 	components/SystemTheme.qml \
 	components/StatRow.qml \
+	components/Sparkline.qml \
 	components/ModeSection.qml \
 	components/ConnectionSection.qml \
 	components/SubscriptionSection.qml \

--- a/Model.js
+++ b/Model.js
@@ -269,9 +269,121 @@ function displayUrl(url, revealed) {
   return revealed === true ? text : maskUrl(text)
 }
 
+// ------------------------------------------------------------------ history
+//
+// Throughput is sampled from the `/traffic` stream that already feeds the two
+// speed readouts, so the curve behind each one is drawn from the very numbers
+// printed on top of it and cannot drift from them.
+//
+// The series survives the panel closing, so reopening continues the curve
+// instead of starting from nothing. What it must not do is close the gap: the
+// curve spaces its samples evenly, so butting the last sample from ten minutes
+// ago against the first from now would draw them as neighbours and misstate
+// when the traffic happened. The seconds the stream was not running are filled
+// in as baseline slots instead — the same flat line the chart shows before it
+// has any data, which is exactly what those seconds are.
+
+// One minute at the stream's one-second cadence. The window is sized to how
+// long the panel is realistically open, not to how much history would be nice:
+// the curve grows in from the right, so a window that never fills would only
+// ever draw a stub against empty space.
+var HISTORY_LIMIT = 60
+
+// QML re-evaluates a `var` property's bindings when it is assigned, not when
+// the array it holds is mutated, so a new array is returned rather than the
+// sample being pushed into the old one.
+// `Array.isArray` rather than `instanceof Array` throughout: the check has to
+// hold for an array that was not built in this realm, which is what the tests
+// hand it when they load this file into a vm context.
+function pushHistory(history, sample, limit) {
+  var cap = Math.max(1, Math.floor(Number(limit) || 0) || 1)
+  var list = Array.isArray(history) ? history : []
+  var next = list.slice(Math.max(0, list.length - cap + 1))
+  var reading = Number(sample)
+  next.push(isFinite(reading) && reading > 0 ? reading : 0)
+  return next
+}
+
+// Records `slots` seconds during which nothing was sampled. Capped at the
+// window: a gap longer than the history leaves nothing of the old series to
+// keep, and the chart correctly comes back as a flat line.
+function padHistory(history, slots, limit) {
+  var list = Array.isArray(history) ? history : []
+  var count = Math.floor(Number(slots))
+  if (!isFinite(count) || count <= 0) return list
+  var cap = Math.max(1, Math.floor(Number(limit) || 0) || 1)
+  var next = list
+  var fill = Math.min(count, cap)
+  for (var i = 0; i < fill; i++) next = pushHistory(next, 0, cap)
+  return next
+}
+
+// Sparkline geometry in a 0..1 box: x runs left to right, y is 0 at the
+// baseline and 1 at the peak, leaving the QML nothing to do but scale.
+//
+// The newest sample is pinned to the right edge and the series grows leftward,
+// so a history that has only just started reads as a short line at "now"
+// instead of a full-width line that is mostly invention.
+//
+// The scale runs from zero to the peak, not from the window's minimum: twice
+// the throughput should draw twice as tall. Normalising to min..max instead
+// would blow an idle line's own jitter up to full height and make a quiet
+// minute look identical to a busy one.
+function peakOf(history) {
+  var list = Array.isArray(history) ? history : []
+  var peak = 0
+  for (var i = 0; i < list.length; i++) {
+    var seen = Number(list[i])
+    if (isFinite(seen) && seen > peak) peak = seen
+  }
+  return peak
+}
+
+function sparkline(history, capacity, scalePeak) {
+  var list = Array.isArray(history) ? history : []
+  var span = Math.max(2, Math.floor(Number(capacity) || 0) || 2) - 1
+  // A caller that draws several series side by side passes one peak for all of
+  // them, so equal heights mean equal throughput across the set. Left at zero,
+  // each series scales to its own window.
+  var forced = Number(scalePeak)
+  var peak = (isFinite(forced) && forced > 0) ? forced : peakOf(list)
+  var points = []
+  var i
+  var newest = list.length - 1
+  for (i = 0; i < list.length; i++) {
+    var reading = Number(list[i])
+    if (!isFinite(reading) || reading < 0) reading = 0
+    points.push({
+      x: Math.max(0, 1 - (newest - i) / span),
+      // Clamped: a shared peak can lag a series that just spiked past it.
+      y: peak > 0 ? Math.min(1, reading / peak) : 0
+    })
+  }
+  // Slots the panel was not open for. They are drawn as a flat line along the
+  // baseline so the box reads as a chart from the first second rather than as
+  // a stub floating at the right edge — but they are returned separately from
+  // the measured points, so the filled area can still mark exactly what was
+  // sampled and the empty stretch stays a bare line.
+  //
+  // With nothing sampled at all, `firstX` is the right edge and the lead spans
+  // the whole width: an empty chart is a flat baseline, not a blank box.
+  var lead = []
+  var firstX = points.length > 0 ? points[0].x : 1
+  if (firstX > 0) {
+    lead.push({ x: 0, y: 0 })
+    lead.push({ x: firstX, y: 0 })
+  }
+
+  return { points: points, lead: lead, peak: peak }
+}
+
 // ---------------------------------------------------------------- formatting
 
-var UNITS = ["B", "KB", "MB", "GB", "TB", "PB"]
+// Binary units, named as binary units. The arithmetic below divides by 1024,
+// which is what mihomo's own dashboard does, so the numbers stay comparable
+// with metacubexd — but calling 854,590,870 bytes "815 MB" understated it by
+// 4.6% against the decimal megabyte every other tool and every ISP quotes.
+var UNITS = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
 
 function formatBytes(bytes) {
   var value = Number(bytes)

--- a/Service.qml
+++ b/Service.qml
@@ -37,6 +37,16 @@ Item {
   property real uploadTotal: 0
   property real upSpeed: 0
   property real downSpeed: 0
+  // The recent history of the two speeds above, appended from the same stream
+  // readings that set them, and drawn behind them. It outlives the panel being
+  // closed; the seconds the stream was down are filled in when it comes back,
+  // so the curve continues rather than restarting. See `Model.padHistory`.
+  property var upHistory: []
+  property var downHistory: []
+  property real trafficIdleSince: 0
+  // The last `/traffic` reading a speed was published from. Not the previous
+  // sample: see `ClashApi.trafficRate`.
+  property var trafficAnchor: null
   property var globalProxyOptions: []
   property string currentGlobalProxy: ""
 
@@ -301,6 +311,8 @@ Item {
       trafficProcess.running = false
       upSpeed = 0
       downSpeed = 0
+      trafficAnchor = null
+      trafficIdleSince = Date.now() / 1000
     }
   }
 
@@ -445,9 +457,14 @@ Item {
       var result = ClashApi.classify(exitCode, versionOut.text, versionErr.text)
       root.apiState = result.ok ? "ok" : result.code
       root.mihomoVersion = result.ok ? ClashApi.parseVersion(result.body).version : ""
+      // Everything below is read from a core that just stopped answering.
+      // Leaving the totals behind would keep them on screen as if they were
+      // still being updated.
       if (!result.ok) {
         root.liveConfigs = null
         root.connectionCount = 0
+        root.downloadTotal = 0
+        root.uploadTotal = 0
       }
     }
   }
@@ -539,13 +556,37 @@ Item {
       onRead: function(line) {
         var sample = ClashApi.parseTrafficLine(line)
         if (!sample) return
-        root.upSpeed = sample.up
-        root.downSpeed = sample.down
+        var now = Date.now() / 1000
+        // First sample of a new stream: charge the time it was down to the
+        // history before appending to it, so the gap occupies the width it
+        // really lasted instead of vanishing between two adjacent points.
+        if (root.trafficAnchor === null && root.trafficIdleSince > 0) {
+          var gap = now - root.trafficIdleSince
+          root.upHistory = Model.padHistory(root.upHistory, gap, Model.HISTORY_LIMIT)
+          root.downHistory = Model.padHistory(root.downHistory, gap, Model.HISTORY_LIMIT)
+          root.trafficIdleSince = 0
+        }
+        var reading = ClashApi.trafficRate(root.trafficAnchor, sample, now)
+        if (!reading) return
+        root.trafficAnchor = reading.anchor
+        // A null rate means this sample came too soon after the anchor to
+        // divide by. Its bytes are still counted; they arrive with the next
+        // reading, and the displayed speed holds until then.
+        if (reading.rate) {
+          root.upSpeed = reading.rate.up
+          root.downSpeed = reading.rate.down
+          root.upHistory = Model.pushHistory(root.upHistory, reading.rate.up, Model.HISTORY_LIMIT)
+          root.downHistory = Model.pushHistory(root.downHistory, reading.rate.down, Model.HISTORY_LIMIT)
+        }
       }
     }
     onExited: {
       root.upSpeed = 0
       root.downSpeed = 0
+      root.trafficAnchor = null
+      // The history is kept; from here on it is a gap, and how long a gap is
+      // only known once the stream comes back.
+      root.trafficIdleSince = Date.now() / 1000
       // The stream ends whenever mihomo restarts or the network blips. Come
       // back on a delay rather than spinning on a core that is still booting.
       if (root.panelOpen) trafficRetry.restart()

--- a/components/ConnectionSection.qml
+++ b/components/ConnectionSection.qml
@@ -27,26 +27,64 @@ Column {
     fontFamily: root.panelFontFamily
   }
 
-  Row {
-    id: trafficRow
+  // Both directions in one chart across the full width, with the two readouts
+  // laid over it. Two half-width charts split the same minute of history into
+  // two narrow windows and made the section read as two unrelated widgets;
+  // sharing one box puts the curves on a common time axis, where the shape of
+  // a transfer — upload spike, download answering it — is actually visible.
+  Item {
+    id: trafficPanel
     width: parent.width
-    spacing: Style.space(10)
+    implicitHeight: trafficRow.implicitHeight + Style.space(12)
+    height: implicitHeight
     opacity: root.live ? 1.0 : 0.45
 
-    Speed {
-      width: (trafficRow.width - trafficRow.spacing) / 2
-      glyph: "↓"
-      label: "DOWNLOAD"
-      metricColor: Color.accent
-      value: Model.formatSpeed(root.service.downSpeed)
+    // One scale for both curves. Overlaid in one box they are compared by
+    // height whether or not that was intended, so scaling each to its own
+    // window would draw a 200 B/s trickle as tall as a 5 MiB/s download.
+    // Upload therefore reads as a low line most of the time, which is the
+    // truth about most sessions.
+    readonly property real seriesPeak: Math.max(Model.peakOf(root.service.downHistory),
+                                                Model.peakOf(root.service.upHistory))
+
+    // Download first, upload over it: upload is the smaller series almost
+    // always, and the one that would otherwise be buried under the other's
+    // fill.
+    Sparkline {
+      anchors.fill: parent
+      history: root.service.downHistory
+      scalePeak: trafficPanel.seriesPeak
+      curveColor: Color.accent
     }
 
-    Speed {
-      width: (trafficRow.width - trafficRow.spacing) / 2
-      glyph: "↑"
-      label: "UPLOAD"
-      metricColor: Color.urgent
-      value: Model.formatSpeed(root.service.upSpeed)
+    Sparkline {
+      anchors.fill: parent
+      history: root.service.upHistory
+      scalePeak: trafficPanel.seriesPeak
+      curveColor: Color.urgent
+    }
+
+    Row {
+      id: trafficRow
+      width: parent.width
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(10)
+
+      Speed {
+        width: (trafficRow.width - trafficRow.spacing) / 2
+        glyph: "↓"
+        label: "DOWNLOAD"
+        metricColor: Color.accent
+        value: Model.formatSpeed(root.service.downSpeed)
+      }
+
+      Speed {
+        width: (trafficRow.width - trafficRow.spacing) / 2
+        glyph: "↑"
+        label: "UPLOAD"
+        metricColor: Color.urgent
+        value: Model.formatSpeed(root.service.upSpeed)
+      }
     }
   }
 

--- a/components/Sparkline.qml
+++ b/components/Sparkline.qml
@@ -1,0 +1,96 @@
+import QtQuick
+import qs.Commons
+import "../Model.js" as Model
+
+// A history curve for a single series, meant to sit behind a readout rather
+// than beside it: the number stays the thing you read, and the curve answers
+// "and how has that been moving" without costing a row of its own.
+//
+// Drawn on a Canvas for the same reason the bar icon is — this is a few dozen
+// pixels tall and the shape is a handful of line segments, so a path stroked
+// at the exact pixel size beats scaling anything.
+//
+// Straight segments, not a spline: every point here was measured, and a
+// smoothed curve would invent values between two samples that never were. The
+// geometry itself lives in Model.js so it can be tested without a compositor.
+Item {
+  id: root
+
+  property var history: []
+  property int capacity: Model.HISTORY_LIMIT
+  // Zero scales the curve to its own window. Set it to share one scale across
+  // several curves drawn side by side, so their heights stay comparable.
+  property real scalePeak: 0
+  property color curveColor: Color.accent
+  // Background, so it reads as texture behind text rather than as a chart
+  // competing with it.
+  property real curveAlpha: 0.45
+  property real areaAlpha: 0.12
+
+  onHistoryChanged: curve.requestPaint()
+  onScalePeakChanged: curve.requestPaint()
+  onCurveColorChanged: curve.requestPaint()
+  onCapacityChanged: curve.requestPaint()
+  onWidthChanged: curve.requestPaint()
+  onHeightChanged: curve.requestPaint()
+
+  Canvas {
+    id: curve
+    anchors.fill: parent
+    antialiasing: true
+
+    onPaint: {
+      var ctx = getContext("2d")
+      ctx.reset()
+      var w = width
+      var h = height
+      if (w <= 0 || h <= 0) return
+
+      var series = Model.sparkline(root.history, root.capacity, root.scalePeak)
+      var points = series.points
+      var lead = series.lead
+      if (lead.length + points.length < 2) return
+
+      // Capped: this is background texture, and a line that thickens with the
+      // box would read as a chart competing with the number in front of it.
+      var stroke = Math.max(1, Math.min(2, h * 0.08))
+      var pad = stroke / 2
+      var baseline = h - pad
+
+      function px(u) { return u * w }
+      function py(v) { return baseline - v * (h - pad * 2) }
+
+      function trace(list, started) {
+        for (var i = 0; i < list.length; i++) {
+          if (started) ctx.lineTo(px(list[i].x), py(list[i].y))
+          else ctx.moveTo(px(list[i].x), py(list[i].y))
+          started = true
+        }
+        return started
+      }
+
+      // The area covers only what was measured, and is filled first so the
+      // line is stroked on top of its own fill rather than under it.
+      if (points.length >= 2) {
+        ctx.beginPath()
+        trace(points, false)
+        ctx.lineTo(px(points[points.length - 1].x), baseline)
+        ctx.lineTo(px(points[0].x), baseline)
+        ctx.closePath()
+        ctx.fillStyle = Qt.rgba(root.curveColor.r, root.curveColor.g,
+                                root.curveColor.b, root.areaAlpha)
+        ctx.fill()
+      }
+
+      // The line runs the full width, baseline included.
+      ctx.beginPath()
+      trace(points, trace(lead, false))
+      ctx.strokeStyle = Qt.rgba(root.curveColor.r, root.curveColor.g,
+                                root.curveColor.b, root.curveAlpha)
+      ctx.lineWidth = stroke
+      ctx.lineJoin = "round"
+      ctx.lineCap = "round"
+      ctx.stroke()
+    }
+  }
+}

--- a/tests/test_clash_api.js
+++ b/tests/test_clash_api.js
@@ -157,7 +157,75 @@ assert.strictEqual(api.parseGlobalProxies("nope"), null)
 const sample = api.parseTrafficLine('{"up":120,"down":4096}')
 assert.strictEqual(sample.up, 120)
 assert.strictEqual(sample.down, 4096)
+assert.strictEqual(sample.hasTotals, false, "a core that sends no totals must say so")
 assert.strictEqual(api.parseTrafficLine(""), null)
 assert.strictEqual(api.parseTrafficLine("{}"), null)
+
+const withTotals = api.parseTrafficLine('{"up":1,"down":2,"upTotal":300,"downTotal":400}')
+assert.strictEqual(withTotals.hasTotals, true)
+assert.strictEqual(withTotals.upTotal, 300)
+assert.strictEqual(withTotals.downTotal, 400)
+
+// `Number(null)` is 0, which would pass for a counter reading zero.
+assert.strictEqual(api.parseTrafficLine('{"up":1,"down":2,"upTotal":null,"downTotal":null}').hasTotals, false)
+assert.strictEqual(api.parseTrafficLine('{"up":1,"down":2,"upTotal":5}').hasTotals, false)
+
+// ------------------------------------------------------------- traffic rate
+//
+// mihomo's `up`/`down` are a buffer its own one-second ticker overwrites,
+// emitted by a second ticker running out of phase with it, so consecutive
+// samples double-count and skip. The totals in the same message are exact, so
+// the rate comes from differencing them over the wall clock that really passed.
+
+const first = api.parseTrafficLine('{"up":9,"down":9,"upTotal":1000,"downTotal":5000}')
+const opening = api.trafficRate(null, first, 100)
+// Objects come out of the vm realm the loader uses, so their prototype is not
+// this realm's; fields are compared rather than whole objects.
+assert.strictEqual(opening.rate.up, 9, "with nothing to difference yet, the core's own reading is all there is")
+assert.strictEqual(opening.rate.down, 9)
+assert.strictEqual(opening.anchor.up, 1000)
+assert.strictEqual(opening.anchor.down, 5000)
+assert.strictEqual(opening.anchor.at, 100)
+
+// One second later: 500 up and 20000 down really moved, whatever `up`/`down` say.
+const second = api.parseTrafficLine('{"up":999999,"down":1,"upTotal":1500,"downTotal":25000}')
+const rated = api.trafficRate(opening.anchor, second, 101)
+assert.strictEqual(rated.rate.up, 500)
+assert.strictEqual(rated.rate.down, 20000)
+assert.strictEqual(rated.anchor.up, 1500)
+assert.strictEqual(rated.anchor.down, 25000)
+assert.strictEqual(rated.anchor.at, 101)
+
+// Half a second is still divisible, and the rate is per second, not per sample.
+const half = api.parseTrafficLine('{"up":0,"down":0,"upTotal":1750,"downTotal":25000}')
+assert.strictEqual(api.trafficRate(rated.anchor, half, 101.5).rate.up, 500)
+
+// Two lines delivered back to back must not divide a whole interval by ~0. The
+// anchor stays put so those bytes land in the next reading instead of spiking.
+const burst = api.parseTrafficLine('{"up":0,"down":0,"upTotal":9000,"downTotal":30000}')
+const held = api.trafficRate(rated.anchor, burst, 101.01)
+assert.strictEqual(held.rate, null, "too soon to divide by")
+assert.strictEqual(held.anchor, rated.anchor, "the anchor must not move")
+// ...and the bytes are still there one second on: 9000-1500 over 1.01s.
+const flushed = api.trafficRate(held.anchor, burst, 102.01)
+assert.ok(Math.abs(flushed.rate.up - 7500 / 1.01) < 1e-9)
+
+// A core that restarted underneath the stream resets its counters; a negative
+// delta must not be shown as a negative speed.
+const restarted = api.parseTrafficLine('{"up":7,"down":7,"upTotal":10,"downTotal":10}')
+const recovered = api.trafficRate(rated.anchor, restarted, 105)
+assert.strictEqual(recovered.rate.up, 7)
+assert.strictEqual(recovered.rate.down, 7)
+assert.strictEqual(recovered.anchor.up, 10)
+assert.strictEqual(recovered.anchor.down, 10)
+assert.strictEqual(recovered.anchor.at, 105)
+
+// Cores too old to send totals keep the old behaviour and never grow an anchor.
+const legacy = api.trafficRate(null, api.parseTrafficLine('{"up":8,"down":9}'), 200)
+assert.strictEqual(legacy.rate.up, 8)
+assert.strictEqual(legacy.rate.down, 9)
+assert.strictEqual(legacy.anchor, null)
+
+assert.strictEqual(api.trafficRate(null, null, 1), null)
 
 console.log("clash API tests passed")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -239,16 +239,149 @@ assert.strictEqual(model.displayUrl("https://example.com/aVeryLongTokenHere", tr
 assert.ok(!model.displayUrl("https://example.com/aVeryLongTokenHere", false)
   .includes("aVeryLongTokenHere"))
 
+// ------------------------------------------------------------------ history
+
+// A `var` property's bindings only re-run on assignment, so the array the
+// panel already holds must not be the one that grew.
+const seed = [1, 2, 3]
+const grown = model.pushHistory(seed, 4, 60)
+assert.strictEqual(seed.length, 3, "the caller's array must not be mutated")
+assert.strictEqual(grown.length, 4)
+assert.strictEqual(grown[3], 4)
+
+// The window slides once it is full; the oldest sample falls off the front.
+let window = []
+for (let i = 1; i <= 8; i++) window = model.pushHistory(window, i, 5)
+assert.strictEqual(window.length, 5)
+assert.strictEqual(window[0], 4)
+assert.strictEqual(window[4], 8)
+
+assert.deepStrictEqual(Array.from(model.pushHistory(null, 7, 3)), [7])
+assert.deepStrictEqual(Array.from(model.pushHistory([], "nope", 3)), [0])
+assert.deepStrictEqual(Array.from(model.pushHistory([], -5, 3)), [0])
+assert.strictEqual(model.pushHistory([1, 2, 3], 4, 0).length, 1, "a zero cap still keeps the newest")
+
+// ---- gaps
+//
+// The history outlives a closed panel, so the seconds nothing was sampled have
+// to occupy the width they really lasted. Otherwise a sample from ten minutes
+// ago ends up drawn next to one from now.
+let before = null
+for (const n of [10, 20, 30]) before = model.pushHistory(before, n, 60)
+const afterGap = model.padHistory(before, 4, 60)
+assert.strictEqual(afterGap.length, 7)
+assert.deepStrictEqual(Array.from(afterGap).slice(3), [0, 0, 0, 0])
+assert.deepStrictEqual(Array.from(afterGap).slice(0, 3), [10, 20, 30],
+  "the samples either side of a gap must survive it")
+
+// A fractional gap counts whole slots only, and a gap of none changes nothing.
+assert.strictEqual(model.padHistory(before, 2.9, 60).length, 5)
+assert.strictEqual(model.padHistory(before, 0, 60), before)
+assert.strictEqual(model.padHistory(before, -3, 60), before)
+assert.strictEqual(model.padHistory(before, NaN, 60), before)
+
+// A gap longer than the window leaves nothing of the old series: the chart
+// comes back flat rather than showing a minute of stale traffic.
+const stale = model.padHistory(before, 5000, 60)
+assert.strictEqual(stale.length, 60)
+assert.ok(Array.from(stale).every(function (n) { return n === 0 }))
+
+// ---- sparkline geometry
+//
+// Newest on the right edge, growing leftward, so a series that has just
+// started does not claim the full width.
+const young = model.sparkline([10, 20], 11)
+assert.strictEqual(young.points.length, 2)
+assert.strictEqual(young.points[1].x, 1, "the newest sample is pinned to the right edge")
+assert.strictEqual(young.points[0].x, 0.9, "one sample back is one slot in from it")
+
+const full = model.sparkline([1, 2, 3], 3)
+assert.strictEqual(full.points[0].x, 0, "a full window starts at the left edge")
+assert.strictEqual(full.points[2].x, 1)
+
+// Zero-based scale: twice the throughput draws twice as tall. A min..max scale
+// would put the quiet second on the floor and the next one at the ceiling.
+const jitter = model.sparkline([70, 71], 60)
+assert.strictEqual(jitter.peak, 71)
+assert.ok(jitter.points[0].y > 0.98, "an idle line's own jitter must not fill the box")
+const doubled = model.sparkline([25, 50], 60)
+assert.strictEqual(doubled.points[0].y, 0.5)
+assert.strictEqual(doubled.points[1].y, 1)
+
+// ---- shared scale
+//
+// Two curves side by side in the same units have to be comparable by height,
+// so the caller passes one peak for both.
+assert.strictEqual(model.peakOf([3, 91, 12]), 91)
+assert.strictEqual(model.peakOf(null), 0)
+assert.strictEqual(model.peakOf([]), 0)
+assert.strictEqual(model.peakOf(["nope", 4]), 4)
+
+const download = model.sparkline([500000, 1000000], 60, 1000000)
+const upload = model.sparkline([1000, 2000], 60, 1000000)
+assert.strictEqual(download.points[1].y, 1)
+assert.ok(upload.points[1].y < 0.01, "a trickle beside a torrent must draw as a low line")
+// Left to itself the same trickle would fill the box — that is the bug the
+// shared peak exists to prevent.
+assert.strictEqual(model.sparkline([1000, 2000], 60).points[1].y, 1)
+
+// A shared peak can lag a series that just spiked past it; the curve clamps
+// rather than drawing outside its own box.
+const spike = model.sparkline([100, 5000], 60, 1000)
+assert.strictEqual(spike.points[1].y, 1)
+// A non-positive or unusable override falls back to the window's own peak.
+assert.strictEqual(model.sparkline([25, 50], 60, 0).points[0].y, 0.5)
+assert.strictEqual(model.sparkline([25, 50], 60, "nope").points[0].y, 0.5)
+
+// An all-zero window has no peak to divide by and must stay flat, not NaN.
+const idle = model.sparkline([0, 0, 0], 60)
+assert.strictEqual(idle.peak, 0)
+assert.ok(idle.points.every(function (point) { return point.y === 0 }))
+
+// ---- the baseline lead
+//
+// The un-sampled part of the window is returned separately so the chart can
+// draw a flat line across it — an empty chart is a baseline, not a blank box —
+// while the filled area still marks only what was measured.
+const empty = model.sparkline([], 60)
+assert.strictEqual(empty.points.length, 0)
+assert.strictEqual(empty.lead.length, 2, "an empty chart still draws a line")
+assert.strictEqual(empty.lead[0].x, 0)
+assert.strictEqual(empty.lead[1].x, 1, "the baseline spans the full width")
+assert.ok(empty.lead.every(function (point) { return point.y === 0 }))
+
+// Partly filled: the lead runs from the left edge to where the samples start.
+const partial = model.sparkline([5, 9], 11)
+assert.strictEqual(partial.lead.length, 2)
+assert.strictEqual(partial.lead[0].x, 0)
+assert.strictEqual(partial.lead[1].x, partial.points[0].x)
+
+// Full window: nothing left to lead in with.
+assert.strictEqual(model.sparkline([1, 2, 3], 3).lead.length, 0)
+
+assert.strictEqual(model.sparkline(null, 60).points.length, 0)
+assert.strictEqual(model.sparkline([], 60).points.length, 0)
+// A capacity too small to space samples in must not divide by zero.
+assert.ok(model.sparkline([1, 2], 1).points.every(function (point) {
+  return isFinite(point.x) && point.x >= 0 && point.x <= 1
+}))
+
 // ---------------------------------------------------------------- formatting
 
 assert.strictEqual(model.formatBytes(0), "0 B")
 assert.strictEqual(model.formatBytes(512), "512 B")
-assert.strictEqual(model.formatBytes(1024), "1.0 KB")
-assert.strictEqual(model.formatBytes(1536), "1.5 KB")
-assert.strictEqual(model.formatBytes(1024 * 1024 * 3.5), "3.5 MB")
-assert.strictEqual(model.formatBytes(1024 * 1024 * 20), "20 MB")
+assert.strictEqual(model.formatBytes(1024), "1.0 KiB")
+assert.strictEqual(model.formatBytes(1536), "1.5 KiB")
+assert.strictEqual(model.formatBytes(1024 * 1024 * 3.5), "3.5 MiB")
+assert.strictEqual(model.formatBytes(1024 * 1024 * 20), "20 MiB")
 assert.strictEqual(model.formatBytes(-5), "0 B")
-assert.strictEqual(model.formatSpeed(2048), "2.0 KB/s")
+assert.strictEqual(model.formatSpeed(2048), "2.0 KiB/s")
+
+// The divisor is 1024, so the unit has to say so: "815 MB" for 854,590,870
+// bytes reads 4.6% low against the megabyte every other tool means.
+assert.strictEqual(model.formatBytes(854590870), "815 MiB")
+assert.ok(model.UNITS.every(function (unit) { return !/^[KMGTP]B$/.test(unit) }),
+  "1024-based units must not be labelled with decimal names")
 
 assert.strictEqual(model.formatDuration(0), "0s")
 assert.strictEqual(model.formatDuration(45), "45s")

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -56,6 +56,31 @@ grep -Fq 'component Speed: Item {' components/ConnectionSection.qml
 grep -Fq 'color: root.textColor' components/ConnectionSection.qml
 ! grep -Fq 'color: Qt.rgba(metricColor.r' components/ConnectionSection.qml
 ! grep -Eq '#[0-9a-fA-F]{6}' components/ConnectionSection.qml
+# Both directions share one full-width chart, drawn from the very stream
+# readings that set the numbers over it, so the two cannot disagree.
+grep -Fq 'history: root.service.downHistory' components/ConnectionSection.qml
+grep -Fq 'history: root.service.upHistory' components/ConnectionSection.qml
+grep -Fq 'Model.pushHistory(root.upHistory' Service.qml
+grep -Fq 'Model.pushHistory(root.downHistory' Service.qml
+[[ "$(grep -c 'Sparkline {' components/ConnectionSection.qml)" -eq 2 ]]
+grep -Fq 'width: parent.width' components/ConnectionSection.qml
+# One scale for both, or the eye reads a trickle as tall as a torrent.
+grep -Fq 'scalePeak: trafficPanel.seriesPeak' components/ConnectionSection.qml
+grep -Fq 'Model.peakOf(root.service.downHistory)' components/ConnectionSection.qml
+# The chart is background: both curves are declared before the readouts.
+[[ "$(grep -n 'Sparkline {' components/ConnectionSection.qml | tail -1 | cut -d: -f1)" -lt \
+   "$(grep -n 'id: trafficRow' components/ConnectionSection.qml | cut -d: -f1)" ]]
+# The history outlives a closed panel, but the seconds nothing was sampled are
+# charged to it, so reopening continues the curve without closing the gap.
+grep -Fq 'Model.padHistory(root.upHistory' Service.qml
+grep -Fq 'Model.padHistory(root.downHistory' Service.qml
+grep -Fq 'root.trafficIdleSince = Date.now() / 1000' Service.qml
+! grep -Fq 'root.upHistory = []' Service.qml
+! grep -Fq 'root.downHistory = []' Service.qml
+# Every point was measured, not interpolated: straight segments only.
+! grep -Eq 'bezierCurveTo|quadraticCurveTo' components/Sparkline.qml
+! grep -Eq '#[0-9a-fA-F]{6}' components/Sparkline.qml
+
 grep -Fq 'label: "TUN"' components/ConnectionSection.qml
 grep -Fq 'root.service.liveConfigs.tunEnabled' components/ConnectionSection.qml
 


### PR DESCRIPTION
## The bug

The DOWNLOAD/UPLOAD readouts took mihomo's `up`/`down` fields at face value. Those come from a snapshot buffer that mihomo's own one-second ticker overwrites, but the `/traffic` stream is written by a **second** ticker started when the socket opened. The two run at the same rate out of phase, so the handler regularly emits one buffer twice and skips the next.

<img width="627" height="739" alt="image" src="https://github.com/user-attachments/assets/40746b37-4a7c-4cc7-b0ea-089573378a0c" />

Measured against the totals carried in the very same messages, **59 of 60 consecutive samples disagreed** with the traffic that actually moved — even though the sum over the minute was correct to within 0.01%. The aggregate was fine; every individual number you looked at was not.

```
报 1,245,515 B/s，实际   154,229 B/s   (虚高 8x)
报   113,888 B/s，实际   979,359 B/s   (虚低 8.6x)
报       235 B/s，实际    68,608 B/s   (虚低 292x)
```

## The fix

`upTotal`/`downTotal` in the same payload are exact and monotonic, and were being discarded. Speeds now come from differencing them over the wall clock that really passed.

Re-measured over the same 60-second window against a live core:

| | mean abs error | worst single sample |
|---|---|---|
| before (`up`/`down` field) | 20,515 B/s | **283x** |
| after (totals difference) | **0 B/s** | **1.0x** |

Edge cases handled: a core that restarts underneath the stream resets its counters, so a negative delta re-anchors rather than drawing a negative speed; two lines delivered back to back leave the anchor where it is, so their bytes land in the next reading instead of being divided by a near-zero interval into a spike; cores too old to send totals keep the previous behaviour.

**The totals were never wrong.** Verified with controlled transfers against the live core: a 20 MB download moved the counters by 20,460,648 bytes (1.023x — TLS and TCP overhead), and per-connection accounting over the proxied path came to 0.990x of payload. No double counting on either the direct or the proxied path.

## Two smaller fixes in the same area

- **`formatBytes` divided by 1024 and labelled the result KB/MB/GB.** Now KiB/MiB/GiB. The arithmetic is unchanged so the numbers stay comparable with metacubexd, but "815 MB" for 854,590,870 bytes read 4.6% low against the megabyte every other tool means.
- **A failed API probe zeroed `connectionCount` but left the transfer totals behind**, so the IPC `status()` could report figures from a core that had stopped answering.

## The chart

The section gains a history chart behind the two readouts, drawn from the same stream readings that set the numbers over it. Both directions share one full-width box on a common time axis — two half-width charts split the same minute into two narrow windows and read as unrelated widgets.

```
A. 刚打开、零数据
|             ↓ DOWNLOAD                           ↑ UPLOAD              |
|              0 B/s                                0 B/s                |
|+----------------------------------------------------------------------+|

B. 采集 25 秒后   (- download, + upload, shared peak 2.6 MiB/s)
|             ↓ DOWNLOAD                   +     + ↑ UPLOAD              |
|              31 KiB/s                    ++    ++ 252 KiB/s            |
|+-----------------------------------------+--+++-+--++++-+++++-+++++--+-|

C. 关闭 12 秒后重开（右侧是补的空档）
|             ↓ DOWNLOAD     +    ++               ↑ UPLOAD              |
|                            ++   + ++                                   |
|+---------------------------+-+++--+-+-+++++-+++++-+++-+--++++-+++++-+++|
```

Decisions worth reviewing:

- **One scale for both curves.** Overlaid, they are compared by height whether or not that was intended, so scaling each to its own window would draw a 200 B/s trickle as tall as a 5 MiB/s download.
- **Straight segments, not a spline.** Every point was measured; a smoothed curve would invent values between samples that never were.
- **The un-sampled span draws a flat baseline** so an empty chart is a line rather than a blank box — but it is kept out of the filled area, which still marks only what was measured.
- **The history outlives the panel closing**, and the seconds nothing was sampled are charged to it when the stream comes back. Reopening continues the curve *without closing the gap*: samples are spaced evenly, so butting one from ten minutes ago against one from now would draw them as neighbours and misstate when the traffic happened. A gap longer than the window leaves nothing of the old series, and the chart correctly comes back flat.

## Known limitation

Network throughput spans three or four orders of magnitude, and the scale is linear and zero-based. In panel B above, the 2.6 MiB/s upload spike flattens the 31 KiB/s download curve onto the floor — with both series now sharing one box, the smaller one can disappear. Switching `reading / peak` to `Math.sqrt(reading / peak)` in `Model.sparkline` fixes the legibility, at the cost of the "equal height means equal throughput" guarantee the shared scale currently makes. Left as-is deliberately; worth a look on real hardware before deciding.

## Testing

`make validate` passes (js tests, qml name checks, shell source checks, qmllint, plugin validate). Rate derivation, gap padding, baseline lead, and shared-peak scaling are covered in `tests/`; placement and lifecycle decisions are pinned in `tests/test_panel_source.sh`.

Note: `Array.isArray` rather than `instanceof Array` in the new code — the tests load these modules into a vm context, where an array built in the other realm fails an `instanceof` check and would silently arrive as empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
