### PR TITLE
Keep the subscription list in mihoro's own directory

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -96,6 +96,10 @@ A subscription URL is a bearer token — the whole of the authentication.
 - The store is written `0600` through a temporary file in the same directory and
   renamed into place. `mihoro.toml` is not ours, so that write keeps the
   permissions it finds.
+- It lives in mihoro's own directory, hardcoded beside the config file mihoro
+  itself hardcodes. The two describe one thing between them — the file mihoro
+  reads names the subscription in effect, this one names the rest — and a path
+  that can be configured is a path that can disagree.
 - It does not go in `shell.json`: that file is world-readable, it is what people
   paste when they ask for help with their bar, and its writer rebuilds plugin
   entries from the manifest schema.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ the panel runs, so nothing is lost on upgrade, and a URL you later set with
 Removing the last subscription clears `remote_config_url`, returning the panel to
 its not-set-up state.
 
-The list lives in `~/.config/omarchy/mihoro-subscriptions.json`, written
-`0600` — subscription URLs are bearer credentials, so they are kept out of
-`shell.json` and never rendered outside the editor.
+The list lives in `~/.config/mihoro/subscriptions.json`, written `0600` —
+subscription URLs are bearer credentials, so they are kept out of `shell.json`
+and never rendered outside the editor.
 
 From a script:
 

--- a/Subscriptions.js
+++ b/Subscriptions.js
@@ -26,8 +26,17 @@ var VERSION = 1
 // row. Long enough for "Provider — backup region", short enough to render.
 var NAME_LIMIT = 60
 
+// mihoro's own directory. mihoro hardcodes `~/.config/mihoro.toml` and does not
+// consult XDG_CONFIG_HOME, so this is hardcoded beside it for the same reason
+// `MihoroConfig.configPath` is: the two have to agree on one place, and a path
+// that can be configured is a path that can disagree.
+//
+// The directory is what lets the file be called what it is. Loose in
+// `~/.config` it would have had to carry a prefix — that directory is shared
+// with every other application, and `subscriptions.json` there says nothing
+// about whose it is.
 function storePath(home) {
-  return String(home || "") + "/.config/omarchy/mihoro-subscriptions.json"
+  return String(home || "") + "/.config/mihoro/subscriptions.json"
 }
 
 function defaults() {

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -144,7 +144,13 @@ grep -Fq 'mktemp' MihoroConfig.js
 grep -Fq 'chmod --reference' MihoroConfig.js
 grep -Fq 'mktemp' Subscriptions.js
 grep -Fq 'chmod 600' Subscriptions.js
-grep -Fq '.config/omarchy/mihoro-subscriptions.json' Subscriptions.js
+# The list lives in mihoro's own directory, hardcoded beside the config file
+# mihoro itself hardcodes — the two have to agree on one place, and a path that
+# can be configured is a path that can disagree.
+grep -Fq '/.config/mihoro/subscriptions.json' Subscriptions.js
+grep -Fq 'Subscriptions.storePath(home)' Service.qml
+# The write makes the directory: nothing else creates ~/.config/mihoro/.
+grep -Fq 'mkdir -p' Subscriptions.js
 
 # stdin is opened per write and closed in onStarted to give `cat` its EOF. A
 # declarative `stdinEnabled: true` would be replaced by that close, and the

--- a/tests/test_subscriptions.js
+++ b/tests/test_subscriptions.js
@@ -1,4 +1,8 @@
 const assert = require("assert")
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execFileSync } = require("child_process")
 const { load } = require("./load")
 
 const subs = load("Subscriptions.js")
@@ -20,8 +24,10 @@ assert.strictEqual(empty.activeId, "")
 same(empty.items, [])
 assert.strictEqual(subs.activeUrl(empty), "")
 assert.strictEqual(subs.count(empty), 0)
+// mihoro's own directory, beside the config file it hardcodes. The name says
+// what the file is because the directory says whose it is.
 assert.strictEqual(subs.storePath("/home/user"),
-  "/home/user/.config/omarchy/mihoro-subscriptions.json")
+  "/home/user/.config/mihoro/subscriptions.json")
 
 // ------------------------------------------------------------------- adding
 
@@ -223,21 +229,43 @@ assert.notStrictEqual(subs.nameError("x".repeat(61)), "")
 
 // ---------------------------------------------------------------- commands
 
-const write = subs.writeCommand("/home/user/.config/omarchy/mihoro-subscriptions.json")
+const STORE = "/home/user/.config/mihoro/subscriptions.json"
+
+const write = subs.writeCommand(STORE)
 assert.strictEqual(write[0], "bash")
 // The store holds several bearer URLs and is the panel's own file: 0600, and
-// renamed into place so a torn write cannot read back as an empty list.
+// renamed into place so a torn write cannot read back as an empty list. It also
+// makes its own directory — nothing else creates `~/.config/mihoro/`.
 assert.ok(write[2].includes("mktemp"))
 assert.ok(write[2].includes("chmod 600"))
 assert.ok(write[2].includes("mv -f"))
-assert.strictEqual(write[write.length - 1],
-  "/home/user/.config/omarchy/mihoro-subscriptions.json")
+assert.ok(write[2].includes("mkdir -p"))
+assert.strictEqual(write[write.length - 1], STORE)
 // The payload arrives on stdin, never as an argument — arguments are visible
 // in the process list.
 assert.ok(!write.some(function (part) { return String(part).includes("token=") }))
 
-const read = subs.readCommand("/home/user/.config/omarchy/mihoro-subscriptions.json")
+const read = subs.readCommand(STORE)
 assert.strictEqual(read[0], "bash")
 assert.ok(read[2].includes("cat"))
+assert.strictEqual(read[read.length - 1], STORE)
+
+// The scripts are the part that touches the user's disk, so they are run rather
+// than read. `Model.js`'s tests do the same with the probe.
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omahoro-subs-"))
+const target = path.join(dir, ".config", "mihoro", "subscriptions.json")
+
+// Nothing there yet reads as nothing, without an error and without a directory.
+assert.strictEqual(
+  execFileSync("bash", subs.readCommand(target).slice(1), { encoding: "utf8" }), "")
+
+// The first write makes the directory and lands 0600.
+execFileSync("bash", subs.writeCommand(target).slice(1),
+  { input: subs.serialize(store), encoding: "utf8" })
+assert.strictEqual(fs.readFileSync(target, "utf8"), subs.serialize(store))
+assert.strictEqual(fs.statSync(target).mode & 0o777, 0o600)
+assert.strictEqual(
+  execFileSync("bash", subs.readCommand(target).slice(1), { encoding: "utf8" }),
+  subs.serialize(store))
 
 console.log("subscription store tests passed")


### PR DESCRIPTION
Follow-up to #7. One constant, its tests, and the docs.

## The problem

`~/.config/omarchy/` is the shell's own directory — bar layout, themes, plugin
installs. Filing the subscription list there put it with the bar's
configuration, which is not what it is. It belongs with mihoro's config: the
two describe one setup between them, the file mihoro reads naming the
subscription in effect and this one naming the rest.

```
~/.config/
├── mihoro.toml               ← mihoro's, the one in effect
├── mihoro/
│   └── subscriptions.json    ← the panel's, the rest of them
└── mihomo/
    └── config.yaml
```

Hardcoded, the way `MihoroConfig.configPath` hardcodes `~/.config/mihoro.toml`.
mihoro does not consult `XDG_CONFIG_HOME` and neither does the panel: the two
have to agree on one place, and a path that can be configured is a path that
can disagree.

**The directory is what lets the file be called what it is.** Loose in
`~/.config` it would have had to carry a prefix — that directory is shared with
every other application, and a bare `subscriptions.json` there says nothing
about whose it is. Nothing else creates `~/.config/mihoro/`, so the write does;
it already ran `mkdir -p` on the store's own directory.

## No migration

The list has never existed outside a working tree. `v0.1.0` is the only tag and
it predates the feature, which landed on main in #7 today — so there is no
installed copy anywhere to move, and migration code would have been machinery
for a case that does not exist.

## Testing

`make validate` passes.

`tests/test_subscriptions.js` now **runs** the read and write scripts rather
than only reading them, the way `tests/test_model.js` already exercises the
probe: nothing there reads as an empty list without an error and without
creating anything, and the first write makes the directory and lands the file
`0600`.

Also run end to end under the sandboxed quickshell harness — fake `$HOME`,
stubbed `mihoro` — adding a subscription into a home with no `~/.config/mihoro/`
at all: the directory was created, both entries came back, `0600`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
