### PR TITLE
Say what failed in three lines, and offer the rest to an agent

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -85,7 +85,8 @@ credential.
   command — a rejected URL is the user's to fix — and only once
   `omarchy-default-agent` names one, because a button that opens nothing
   explains nothing. It never opens on its own: a failed update must not spawn a
-  terminal nobody asked for.
+  terminal nobody asked for. It carries the plain foreground, not `urgent`: the
+  failure is the notice line above it, and the button is an offer.
 - **A refused or failed action reports on the page it happened on.** A notice
   that only renders on page one turns a rejected subscription switch into the
   panel appearing to ignore the click. That was a real bug.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,7 +68,24 @@ credential.
   reopens where it was left is a popup that shows the wrong thing after the
   panel has been shut for a day.
 - Page one is the whole state at a glance: what it is doing, what went wrong, or
-  why the proxy is not connected, in **one** notice line.
+  why the proxy is not connected, in **one** notice line. A failure may take up
+  to three, and no more — past that the panel is more error than panel. The
+  clamp is `maximumLineCount`, not a character count: it has to hold against the
+  reader's font size and the panel's real width.
+- **A message from outside is shortened before it is shown, never by the clamp.**
+  mihoro quotes back the URL it was given and the body it could not parse, so
+  the notice would otherwise render a bearer token and several kilobytes on one
+  line. `Model.noticeMessage` redacts URLs to their host and collapses quoted
+  payloads first; eliding first could stop halfway through a token and leave the
+  front of it on screen.
+- **What will not fit goes to an agent, on a button.** Three lines cannot hold
+  why `mihoro update` failed, and the panel can neither read a journal nor fetch
+  a URL to find out. `Diagnose...` writes the whole output to a `0600` file and
+  points the user's default agent at it. It is offered only for a failed mihoro
+  command — a rejected URL is the user's to fix — and only once
+  `omarchy-default-agent` names one, because a button that opens nothing
+  explains nothing. It never opens on its own: a failed update must not spawn a
+  terminal nobody asked for.
 - **A refused or failed action reports on the page it happened on.** A notice
   that only renders on page one turns a rejected subscription switch into the
   panel appearing to ignore the click. That was a real bug.
@@ -92,7 +109,8 @@ A subscription URL is a bearer token — the whole of the authentication.
 - It is never rendered outside the editor. Rows carry the name the user gave the
   subscription, which defaults to the URL's host.
 - It never reaches a command line; it goes over stdin. Arguments are visible in
-  the process list.
+  the process list. This is why the diagnosis prompt carries paths rather than
+  the failure output: `omarchy-agent --prompt` becomes argv.
 - The store is written `0600` through a temporary file in the same directory and
   renamed into place. `mihoro.toml` is not ours, so that write keeps the
   permissions it finds.

--- a/Model.js
+++ b/Model.js
@@ -164,6 +164,39 @@ function parseStageLine(line) {
   return { kind: "other", name: "", detail: trimmed }
 }
 
+// A failure message quotes back what mihoro was given and what it got: the
+// subscription URL on a network error, the whole response body when it could
+// not be parsed. Both are hostile to a notice line — the URL is the whole of
+// the authentication, and a body runs to kilobytes on one line.
+
+// Only the host survives. It is what identifies the subscription when
+// diagnosing, and it is the part that is not a credential.
+function redactUrls(text) {
+  return String(text === undefined || text === null ? "" : text)
+    .replace(/https?:\/\/[^\s'"()<>]+/g, function (url) {
+      var rest = url.replace(/^https?:\/\//, "")
+      var cut = rest.search(/[\/?#]/)
+      return cut < 0 ? rest : rest.substring(0, cut) + "/…"
+    })
+}
+
+// A quoted run long enough to be a payload rather than a field name says
+// nothing a reader can use, and truncation would leave part of it on screen.
+// Short quotes are the ones carrying the meaning — `missing field "proxies"`.
+function collapseQuoted(text, max) {
+  var limit = Number(max) || 60
+  return String(text === undefined || text === null ? "" : text)
+    .replace(/"([^"]*)"/g, function (whole, inner) {
+      return inner.length > limit ? '"…"' : whole
+    })
+}
+
+// Redact before shortening, always: eliding first could stop halfway through a
+// token and leave the front of it on screen.
+function noticeMessage(text) {
+  return elide(collapseQuoted(redactUrls(text), 60), 240)
+}
+
 // The message to show when a staged command exits non-zero. A failed stage is
 // far more useful than the exit code, so it wins over stderr.
 function stageFailureMessage(output, fallback) {
@@ -171,14 +204,15 @@ function stageFailureMessage(output, fallback) {
   for (var i = 0; i < lines.length; i++) {
     var parsed = parseStageLine(lines[i])
     if (parsed && parsed.kind === "fail") {
-      if (parsed.name !== "" && parsed.detail !== "") return parsed.name + ": " + parsed.detail
-      return parsed.detail !== "" ? parsed.detail : parsed.name
+      var named = parsed.name !== "" && parsed.detail !== ""
+      return noticeMessage(named ? parsed.name + ": " + parsed.detail
+        : (parsed.detail !== "" ? parsed.detail : parsed.name))
     }
   }
   var trimmed = stripAnsi(output).trim()
   if (trimmed !== "") {
     var last = trimmed.split("\n")
-    return elide(last[last.length - 1].trim(), 160)
+    return noticeMessage(last[last.length - 1].trim())
   }
   return String(fallback || "mihoro reported a failure.")
 }
@@ -187,6 +221,90 @@ function elide(text, max) {
   var value = String(text === undefined || text === null ? "" : text).replace(/\s+/g, " ").trim()
   var limit = Number(max) || 80
   return value.length > limit ? value.substring(0, limit - 1) + "…" : value
+}
+
+// -------------------------------------------------------------- AI diagnosis
+//
+// Omarchy's crash watcher already answers the question of how a shell offers a
+// diagnosis: check that a default agent has been chosen, gather the facts, and
+// point the agent at them instead of pasting them into the prompt. Both halves
+// matter here — `omarchy-default-agent` prints nothing until the user picks
+// one, and a button that opens nothing explains nothing.
+
+// Only a staged mihoro command qualifies. A rejected URL is the user's to fix
+// and an agent would only repeat the validation message back; a failed write is
+// a permissions problem with no output worth reading.
+var DIAGNOSABLE = [
+  { kind: "update", command: "mihoro update --config" },
+  { kind: "init",   command: "mihoro init -y" },
+  { kind: "apply",  command: "mihoro apply" }
+]
+
+function diagnosableCommand(kind) {
+  var key = String(kind === undefined || kind === null ? "" : kind)
+  for (var i = 0; i < DIAGNOSABLE.length; i++)
+    if (DIAGNOSABLE[i].kind === key) return DIAGNOSABLE[i].command
+  return ""
+}
+
+function defaultAgentCommand() { return ["omarchy-default-agent"] }
+
+function canDiagnose(kind, agent) {
+  return String(agent || "") !== "" && diagnosableCommand(kind) !== ""
+}
+
+function failureLogPath(home) {
+  return String(home || "") + "/.local/state/omarchy/mihoro/last-failure.log"
+}
+
+// Written the way the subscription store is, and for the same reason: what the
+// command printed quotes back the URL it was given and whatever the server
+// answered with. State rather than config — it is a transcript of one failure,
+// replaced by the next one, and worth nothing after it.
+var FAILURE_LOG_SCRIPT = [
+  "set -eu",
+  "target=$1",
+  "dir=$(dirname -- \"$target\")",
+  "mkdir -p -- \"$dir\"",
+  "tmp=$(mktemp -- \"$dir/.mihoro-failure.XXXXXX\")",
+  "trap 'rm -f -- \"$tmp\"' EXIT",
+  "cat > \"$tmp\"",
+  "chmod 600 -- \"$tmp\"",
+  "mv -f -- \"$tmp\" \"$target\"",
+  "trap - EXIT"
+].join("\n")
+
+function failureLogWriteCommand(path) {
+  return ["bash", "-c", FAILURE_LOG_SCRIPT, "omahoro-failure-log", String(path)]
+}
+
+// Paths and the command that failed, nothing more. This string becomes argv,
+// which the process list shows to every user on the machine.
+function diagnosePrompt(kind, logPath, configPath) {
+  var command = diagnosableCommand(kind)
+  if (command === "") command = "mihoro"
+  return [
+    "`" + command + "` failed on this Omarchy machine and I want to know why.",
+    "",
+    "Its output, stdout and stderr together, is in:",
+    "  " + String(logPath || ""),
+    "",
+    "mihoro's configuration is in:",
+    "  " + String(configPath || ""),
+    "",
+    "The subscription URL in that file is a bearer credential — the whole of the",
+    "authentication. Read it if you need it, but do not print it, and do not put",
+    "it in a commit, an issue, or a paste.",
+    "",
+    "Work out what failed and tell me how to fix it. Worth ruling out: the",
+    "subscription answering with something that is not a Clash config, a URL that",
+    "has expired or is being rejected, and mihomo.service failing to come back up",
+    "(journalctl --user -u mihomo.service -n 50 --no-pager)."
+  ].join("\n")
+}
+
+function diagnoseCommand(prompt) {
+  return ["omarchy-agent", "--prompt", String(prompt || "")]
 }
 
 // ---------------------------------------------------------- connection state

--- a/Panel.qml
+++ b/Panel.qml
@@ -405,14 +405,27 @@ Panel {
           // reports here, and a silent no-op reads as the panel ignoring the
           // click.
           Item {
+            id: noticeBlock
             visible: (root.panelPage === 1 || root.panelPage === 2) && text !== ""
             width: parent.width
-            implicitHeight: Math.max(noticeText.implicitHeight, noticeClose.visible ? noticeClose.implicitHeight : 0)
+            implicitHeight: Math.max(noticeText.implicitHeight,
+                noticeClose.visible ? noticeClose.implicitHeight : 0)
+              + (offersDiagnosis ? noticeDiagnose.implicitHeight + Style.space(4) : 0)
             property alias text: noticeText.text
+
+            // One condition, read by both the button and this block's height.
+            // Reading the button's own `visible` here instead would tie the
+            // block to a value QQuickItem propagates downward from it: the
+            // first time the button hid, the block would hide with it, and the
+            // child would then read false for good. That latch is why the
+            // button never appeared at all.
+            readonly property bool offersDiagnosis: mihoro.actionStatus === ""
+              && Model.canDiagnose(mihoro.lastErrorKind, mihoro.defaultAgent)
 
             Text {
               id: noticeText
               anchors.left: parent.left
+              anchors.top: parent.top
               anchors.right: noticeClose.visible ? noticeClose.left : parent.right
               anchors.rightMargin: noticeClose.visible ? Style.space(6) : 0
               text: mihoro.actionStatus !== "" ? mihoro.actionStatus
@@ -439,31 +452,29 @@ Panel {
               text: "×"
               foreground: root.urgent
               bordered: false
-              fontSize: Style.font.body
+              fontSize: Style.font.bodySmall
               onClicked: mihoro.clearNotice()
             }
-          }
 
-          // Three lines cannot hold why a mihoro command failed, and the panel
-          // cannot read journals or fetch a URL to find out. Handing the whole
-          // output to the user's own agent is the honest way to say more —
-          // offered as a button, never opened on its own: a failed update must
-          // not spawn a terminal the user did not ask for.
-          Item {
-            visible: (root.panelPage === 1 || root.panelPage === 2) && noticeDiagnose.visible
-            width: parent.width
-            implicitHeight: noticeDiagnose.implicitHeight
-
+            // Three lines cannot hold why a mihoro command failed, and the
+            // panel can neither read a journal nor fetch a URL to find out.
+            // Handing the whole output to the user's own agent is the honest
+            // way to say more — offered as a button, never opened on its own: a
+            // failed update must not spawn a terminal nobody asked for.
             Button {
               id: noticeDiagnose
+              visible: noticeBlock.offersDiagnosis
               anchors.left: parent.left
+              anchors.top: noticeText.bottom
+              anchors.topMargin: Style.space(4)
               // `...` because it opens a terminal workflow rather than
               // finishing the job here.
               text: "Diagnose..."
-              visible: mihoro.actionStatus === ""
-                && Model.canDiagnose(mihoro.lastErrorKind, mihoro.defaultAgent)
-              foreground: root.urgent
-              bordered: false
+              // Not urgent: urgent is failure and destruction, and the failure
+              // is the line above. Not accent either, which means connected or
+              // selected. An offer reads as a plain action.
+              foreground: root.foreground
+              bordered: true
               fontSize: Style.font.bodySmall
               onClicked: mihoro.diagnose()
             }

--- a/Panel.qml
+++ b/Panel.qml
@@ -422,6 +422,13 @@ Panel {
               font.family: root.fontFamily
               font.pixelSize: Style.font.bodySmall
               wrapMode: Text.WordWrap
+              // Three lines is what a failure gets before the panel is more
+              // error than panel. Qt clamps against the real width and the
+              // reader's own font size; counting characters here would be wrong
+              // the moment either changed. The message is already shortened and
+              // redacted upstream, so a clamp can only ever drop wording.
+              maximumLineCount: 3
+              elide: Text.ElideRight
             }
 
             Button {
@@ -434,6 +441,31 @@ Panel {
               bordered: false
               fontSize: Style.font.body
               onClicked: mihoro.clearNotice()
+            }
+          }
+
+          // Three lines cannot hold why a mihoro command failed, and the panel
+          // cannot read journals or fetch a URL to find out. Handing the whole
+          // output to the user's own agent is the honest way to say more —
+          // offered as a button, never opened on its own: a failed update must
+          // not spawn a terminal the user did not ask for.
+          Item {
+            visible: (root.panelPage === 1 || root.panelPage === 2) && noticeDiagnose.visible
+            width: parent.width
+            implicitHeight: noticeDiagnose.implicitHeight
+
+            Button {
+              id: noticeDiagnose
+              anchors.left: parent.left
+              // `...` because it opens a terminal workflow rather than
+              // finishing the job here.
+              text: "Diagnose..."
+              visible: mihoro.actionStatus === ""
+                && Model.canDiagnose(mihoro.lastErrorKind, mihoro.defaultAgent)
+              foreground: root.urgent
+              bordered: false
+              fontSize: Style.font.bodySmall
+              onClicked: mihoro.diagnose()
             }
           }
 

--- a/Service.qml
+++ b/Service.qml
@@ -71,6 +71,30 @@ Item {
   property string actionStatus: ""
   property string lastError: ""
 
+  // The one error worth handing to an agent is a staged mihoro command that
+  // failed: its output runs to kilobytes and its cause is usually somewhere the
+  // panel cannot look. A rejected URL is the user's to fix and a failed write is
+  // a permissions problem, so neither sets this.
+  //
+  // The kind travels with the message, never outliving it — see reportError.
+  property string lastErrorKind: ""
+  property string lastFailureOutput: ""
+
+  // Empty until the user picks one; Omarchy ships with no default agent, and
+  // there is nothing to offer until there is something to open.
+  property string defaultAgent: ""
+
+  onLastErrorChanged: if (lastError === "") lastErrorKind = ""
+
+  // Every error that is not a failed mihoro command reports through here, so it
+  // takes the diagnosis offer down with it. Without this the button would
+  // survive its own failure and point the agent at a log the user has already
+  // moved past.
+  function reportError(message) {
+    lastErrorKind = ""
+    lastError = message
+  }
+
   readonly property int refreshIntervalSec: {
     var raw = settings ? settings.refreshIntervalSec : undefined
     var value = parseInt(String(raw === undefined || raw === null ? 30 : raw), 10)
@@ -318,7 +342,7 @@ Item {
     if (problem === "") problem = Subscriptions.nameError(name)
     if (problem === "") problem = duplicateError(text, "")
     if (problem !== "") {
-      lastError = problem
+      reportError(problem)
       return false
     }
     lastError = ""
@@ -338,7 +362,7 @@ Item {
     if (problem === "") problem = Subscriptions.nameError(name)
     if (problem === "") problem = duplicateError(text, entry.id)
     if (problem !== "") {
-      lastError = problem
+      reportError(problem)
       return false
     }
     lastError = ""
@@ -381,6 +405,27 @@ Item {
     subscriptionsWriteProcess.running = true
   }
 
+  // Checked per open rather than once at startup, so choosing an agent takes
+  // effect without restarting the shell. omarchy-crash-watch re-checks per crash
+  // for the same reason.
+  function refreshDefaultAgent() {
+    if (defaultAgentProcess.running) return
+    defaultAgentProcess.command = Model.defaultAgentCommand()
+    defaultAgentProcess.running = true
+  }
+
+  // The output quotes back the URL it was given and whatever the server
+  // answered with, so it goes to a 0600 file rather than into the prompt:
+  // `--prompt` becomes argv, and the process list is world-readable.
+  function diagnose() {
+    if (!Model.canDiagnose(lastErrorKind, defaultAgent)) return
+    if (failureLogWriteProcess.running || diagnoseProcess.running) return
+    _pendingFailureLog = lastFailureOutput
+    failureLogWriteProcess.command = Model.failureLogWriteCommand(Model.failureLogPath(home))
+    failureLogWriteProcess.stdinEnabled = true
+    failureLogWriteProcess.running = true
+  }
+
   function runAction(kind, command, label) {
     if (actionProcess.running) return
     actionKind = kind
@@ -400,6 +445,7 @@ Item {
   property string _actionError: ""
   property string _pendingClipboard: ""
   property string _pendingSubscriptions: ""
+  property string _pendingFailureLog: ""
   property bool _subscriptionsQueued: false
 
   function writeConfig(changes, thenAction) {
@@ -462,6 +508,7 @@ Item {
     if (panelOpen) {
       refresh()
       refreshConnections()
+      refreshDefaultAgent()
     }
     syncTraffic()
   }
@@ -554,9 +601,54 @@ Item {
         actionStatusTimer.restart()
       } else {
         root.actionStatus = ""
-        root.lastError = "Could not open the Mihoro installation guide."
+        root.reportError("Could not open the Mihoro installation guide.")
       }
       settleTimer.restart()
+    }
+  }
+
+  Process {
+    id: defaultAgentProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: defaultAgentOut; waitForEnd: true }
+    onExited: function(exitCode) {
+      root.defaultAgent = exitCode === 0 ? String(defaultAgentOut.text || "").trim() : ""
+    }
+  }
+
+  Process {
+    id: failureLogWriteProcess
+    running: false
+    command: []
+    // Set per write, not bound: `onStarted` closes stdin, and a binding would
+    // fight that.
+    stdinEnabled: false
+    onStarted: {
+      failureLogWriteProcess.write(root._pendingFailureLog)
+      root._pendingFailureLog = ""
+      failureLogWriteProcess.stdinEnabled = false
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        root.reportError("Could not save the failure log.")
+        return
+      }
+      diagnoseProcess.command = Model.diagnoseCommand(
+        Model.diagnosePrompt(root.lastErrorKind, Model.failureLogPath(root.home),
+          root.mihoroConfigPath))
+      diagnoseProcess.running = true
+    }
+  }
+
+  Process {
+    id: diagnoseProcess
+    running: false
+    command: []
+    onExited: function(exitCode) {
+      // omarchy-agent detaches the terminal, so a non-zero exit is the launch
+      // itself failing rather than the agent finishing.
+      if (exitCode !== 0) root.reportError("Could not open the diagnosis.")
     }
   }
 
@@ -675,7 +767,7 @@ Item {
       var result = ClashApi.classify(exitCode, proxySelectOut.text, proxySelectErr.text)
       if (!result.ok) {
         root.cancelGlobalSelection()
-        root.lastError = result.message
+        root.reportError(result.message)
         return
       }
       var selected = root.pendingGlobalProxy
@@ -750,7 +842,7 @@ Item {
       if (exitCode !== 0 || root._pendingClipboard.trim() === "") {
         root._pendingClipboard = ""
         root.actionStatus = ""
-        root.lastError = "Could not export proxy info."
+        root.reportError("Could not export proxy info.")
         return
       }
       clipboardProcess.stdinEnabled = true
@@ -770,7 +862,8 @@ Item {
     }
     onExited: function(exitCode) {
       root.actionStatus = exitCode === 0 ? "Proxy export copied." : ""
-      root.lastError = exitCode === 0 ? "" : "Could not copy proxy info."
+      if (exitCode === 0) root.lastError = ""
+      else root.reportError("Could not copy proxy info.")
       if (exitCode === 0) actionStatusTimer.restart()
     }
   }
@@ -794,7 +887,7 @@ Item {
       if (exitCode !== 0) {
         root._afterWrite = ""
         root.pendingMode = ""
-        root.lastError = Model.elide(writeErr.text || "Could not write mihoro.toml.", 160)
+        root.reportError(Model.noticeMessage(writeErr.text || "Could not write mihoro.toml."))
         // The file on disk is not what the panel just assumed it was.
         root.refresh()
         return
@@ -833,8 +926,8 @@ Item {
     onExited: function(exitCode) {
       if (exitCode !== 0) {
         root._subscriptionsQueued = false
-        root.lastError = Model.elide(
-          subscriptionsWriteErr.text || "Could not save the subscription list.", 160)
+        root.reportError(Model.noticeMessage(
+          subscriptionsWriteErr.text || "Could not save the subscription list."))
         // What is on screen is not what is on disk; the file is the truth.
         root.loadSubscriptions()
         return
@@ -890,9 +983,12 @@ Item {
         root.desiredActive = -1
         root.pendingMode = ""
         root.actionStatus = ""
-        root.lastError = Model.stageFailureMessage(
-          root._actionOutput + "\n" + root._actionError,
+        // The notice gets a message it can render; the log keeps the whole of
+        // what was printed, for an agent that can read more than three lines.
+        root.lastFailureOutput = root._actionOutput + "\n" + root._actionError
+        root.lastError = Model.stageFailureMessage(root.lastFailureOutput,
           "mihoro " + kind + " failed.")
+        root.lastErrorKind = kind
       }
       root.actionKind = ""
       root.actionFinished(kind, ok)

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -208,6 +208,95 @@ assert.strictEqual(model.stageFailureMessage("", "fallback"), "fallback")
 assert.strictEqual(model.stageFailureMessage("something went sideways\n", "fallback"),
   "something went sideways")
 
+// A failure message is a bearer credential hazard and a length hazard: mihoro
+// echoes the URL it was given, and serde echoes the whole body it could not
+// parse. Both land in a notice line that has three lines to say something
+// useful in.
+
+// mihoro reports a network failure by quoting the subscription URL twice. The
+// token is the whole of the authentication, so the host survives and the rest
+// does not.
+const networkFailure = '  ✗ config: failed to GET from ' +
+  "'https://sub.example.com/api/v1/client/subscribe?token=SECRET123': " +
+  'error sending request for url ' +
+  '(https://sub.example.com/api/v1/client/subscribe?token=SECRET123): ' +
+  'client error (Connect): unexpected EOF\n'
+const networkMessage = model.stageFailureMessage(networkFailure, "fallback")
+assert.ok(!networkMessage.includes("SECRET123"), networkMessage)
+assert.ok(!networkMessage.includes("/api/v1/client/subscribe"), networkMessage)
+assert.ok(networkMessage.includes("sub.example.com"), networkMessage)
+assert.ok(networkMessage.includes("failed to GET"), networkMessage)
+
+// A subscription that answers with a node list rather than a Clash config makes
+// serde quote the entire body back. The quoted payload carries the account's
+// UUID, and at 6KB it is neither readable nor renderable.
+const echoedBody = Array.from({ length: 40 }, (_, i) =>
+  "hysteria2://3ec68822-94e5-433b-938e-399052b1d557@sg" + i +
+  ".example.com:8443/?insecure=1&sni=localhost#node" + i).join(" ")
+const bodyFailure = '  ✗ config: invalid type: string "' + echoedBody +
+  '", expected struct MihomoYamlConfig\n'
+const bodyMessage = model.stageFailureMessage(bodyFailure, "fallback")
+assert.ok(!bodyMessage.includes("3ec68822"), bodyMessage)
+assert.ok(bodyMessage.length <= 240, "length " + bodyMessage.length)
+// The ends carry the meaning; only the quoted middle is worth nothing.
+assert.ok(bodyMessage.startsWith("config: invalid type: string"), bodyMessage)
+assert.ok(bodyMessage.includes("expected struct MihomoYamlConfig"), bodyMessage)
+
+// A quoted string short enough to read is left alone: collapsing "proxies"
+// would throw away the only part that says what is missing.
+assert.strictEqual(
+  model.stageFailureMessage('  ✗ config: missing field "proxies"\n', "fallback"),
+  'config: missing field "proxies"')
+
+// Nothing quoted and nothing to redact still cannot run past the cap.
+const longPlain = model.stageFailureMessage("  ✗ config: " + "x".repeat(500) + "\n", "fallback")
+assert.ok(longPlain.length <= 240, "length " + longPlain.length)
+assert.ok(longPlain.endsWith("…"), longPlain)
+
+// ------------------------------------------------------------- AI diagnosis
+//
+// A failed mihoro command is the one error worth handing to an agent: the
+// output is long, and the cause is usually somewhere the panel cannot look.
+
+assert.deepStrictEqual(Array.from(model.defaultAgentCommand()), ["omarchy-default-agent"])
+
+assert.strictEqual(model.failureLogPath("/home/u"),
+  "/home/u/.local/state/omarchy/mihoro/last-failure.log")
+
+// The log holds a server's answer verbatim, so it is written the way the
+// subscription store is: 0600, through a temporary file in the same directory.
+const logPath = model.failureLogPath("/home/u")
+const logCommand = model.failureLogWriteCommand(logPath)
+assert.strictEqual(logCommand[0], "bash")
+assert.strictEqual(logCommand[1], "-c")
+assert.ok(logCommand[2].includes("chmod 600"), logCommand[2])
+assert.ok(logCommand[2].includes("mkdir -p"), logCommand[2])
+assert.strictEqual(logCommand[logCommand.length - 1], logPath)
+
+// The prompt travels as argv, where the process list can read it. It carries
+// paths and the command that failed — never the output, and never the URL.
+const updatePrompt = model.diagnosePrompt("update", logPath, "/home/u/.config/mihoro.toml")
+assert.ok(updatePrompt.includes("mihoro update --config"), updatePrompt)
+assert.ok(updatePrompt.includes(logPath), updatePrompt)
+assert.ok(updatePrompt.includes("/home/u/.config/mihoro.toml"), updatePrompt)
+assert.ok(!/https?:\/\//.test(updatePrompt), updatePrompt)
+
+// Each kind names the command the user actually ran, so the agent is not left
+// guessing which of the three failed.
+assert.ok(model.diagnosePrompt("init", logPath, "/c").includes("mihoro init -y"))
+assert.ok(model.diagnosePrompt("apply", logPath, "/c").includes("mihoro apply"))
+
+const diagnose = model.diagnoseCommand(updatePrompt)
+assert.deepStrictEqual([diagnose[0], diagnose[1]], ["omarchy-agent", "--prompt"])
+assert.strictEqual(diagnose[2], updatePrompt)
+
+// Only a staged mihoro command earns the button. A rejected URL is the user's
+// to fix, and a failed write is not something an agent can read a log about.
+assert.strictEqual(model.canDiagnose("update", "claude"), true)
+assert.strictEqual(model.canDiagnose("update", ""), false)
+assert.strictEqual(model.canDiagnose("", "claude"), false)
+assert.strictEqual(model.canDiagnose("validation", "claude"), false)
+
 // ------------------------------------------------------------ subscriptions
 
 assert.strictEqual(model.subscriptionUrlError("https://example.com/sub"), "")

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# `set -e` is specified to ignore a command whose status is inverted with `!`,
+# so every `! grep ...` in here was a comment with a grep in it: the match was
+# found, the negation failed, and the script carried on to print "passed". The
+# diagnosis button was swallowed by a rule this file claimed to be holding.
+refute() {
+  if grep "$@" >/dev/null 2>&1; then
+    printf 'unexpected match: grep %s\n' "$*" >&2
+    exit 1
+  fi
+}
+
 # Quickshell's Process, Panel, and the qs.Ui kit only exist inside a running
 # Omarchy shell, so the QML behaviour that matters is pinned here at the source
 # level. Each check stands for a decision that is easy to undo by accident.
@@ -42,8 +53,8 @@ grep -Fq 'running: root.panelOpen' Service.qml
 # item's own state string and every field off it reads as undefined.
 grep -Fq 'Model.connectionState(probe, apiState)' Service.qml
 grep -Fq 'mihoro.connection.label' Panel.qml
-! grep -rFq 'mihoro.state' Panel.qml
-! grep -rEq '\broot\.state\b' Service.qml
+refute -rFq 'mihoro.state' Panel.qml
+refute -rEq '\broot\.state\b' Service.qml
 
 # Live traffic is presented as two centered, equally sized metrics with stable
 # semantic colours: green for download and red for upload.
@@ -54,8 +65,8 @@ grep -Fq 'metricColor: Color.urgent' components/ConnectionSection.qml
 grep -Fq 'horizontalAlignment: Text.AlignHCenter' components/ConnectionSection.qml
 grep -Fq 'component Speed: Item {' components/ConnectionSection.qml
 grep -Fq 'color: root.textColor' components/ConnectionSection.qml
-! grep -Fq 'color: Qt.rgba(metricColor.r' components/ConnectionSection.qml
-! grep -Eq '#[0-9a-fA-F]{6}' components/ConnectionSection.qml
+refute -Fq 'color: Qt.rgba(metricColor.r' components/ConnectionSection.qml
+refute -Eq '#[0-9a-fA-F]{6}' components/ConnectionSection.qml
 # Both directions share one full-width chart, drawn from the very stream
 # readings that set the numbers over it, so the two cannot disagree.
 grep -Fq 'history: root.service.downHistory' components/ConnectionSection.qml
@@ -75,11 +86,11 @@ grep -Fq 'Model.peakOf(root.service.downHistory)' components/ConnectionSection.q
 grep -Fq 'Model.padHistory(root.upHistory' Service.qml
 grep -Fq 'Model.padHistory(root.downHistory' Service.qml
 grep -Fq 'root.trafficIdleSince = Date.now() / 1000' Service.qml
-! grep -Fq 'root.upHistory = []' Service.qml
-! grep -Fq 'root.downHistory = []' Service.qml
+refute -Fq 'root.upHistory = []' Service.qml
+refute -Fq 'root.downHistory = []' Service.qml
 # Every point was measured, not interpolated: straight segments only.
-! grep -Eq 'bezierCurveTo|quadraticCurveTo' components/Sparkline.qml
-! grep -Eq '#[0-9a-fA-F]{6}' components/Sparkline.qml
+refute -Eq 'bezierCurveTo|quadraticCurveTo' components/Sparkline.qml
+refute -Eq '#[0-9a-fA-F]{6}' components/Sparkline.qml
 
 grep -Fq 'label: "TUN"' components/ConnectionSection.qml
 grep -Fq 'root.service.liveConfigs.tunEnabled' components/ConnectionSection.qml
@@ -129,14 +140,14 @@ grep -Fq 'if (applying) return false' Service.qml
 
 # The credential is absent from read-only mode; it only enters a control after
 # the user explicitly chooses Edit/Add. Rows carry the name, never the URL.
-! grep -Fq 'property bool revealed:' components/SubscriptionSection.qml
-! grep -Fq 'Model.displayUrl(' components/SubscriptionSection.qml
-! grep -Fq 'modelData.url' components/SubscriptionSection.qml
+refute -Fq 'property bool revealed:' components/SubscriptionSection.qml
+refute -Fq 'Model.displayUrl(' components/SubscriptionSection.qml
+refute -Fq 'modelData.url' components/SubscriptionSection.qml
 # The list is not in shell.json: that file is world-readable, people paste it
 # when they ask for help with their bar, and its writer rebuilds plugin entries
 # from the manifest schema.
-! grep -Fq 'updateEntryInline' Service.qml Panel.qml
-! grep -Fq '"key": "subscriptions"' manifest.json
+refute -Fq 'updateEntryInline' Service.qml Panel.qml
+refute -Fq '"key": "subscriptions"' manifest.json
 
 # Both writes are atomic. mihoro.toml keeps its own permissions; the panel's own
 # store is 0600 outright — it holds several bearer URLs.
@@ -164,17 +175,17 @@ grep -Fq 'onCopyProxyRequested: mihoro.copyProxyExport()' Panel.qml
 grep -Fq 'text: "Copy proxy export"' components/PanelMenu.qml
 grep -Fq 'https://github.com/huacnlee/omarchy-mihoro' components/PanelMenu.qml
 grep -Fq 'text: "Mihoro docs..."' components/PanelMenu.qml
-! grep -Fq 'text: "Install Guides"' components/PanelMenu.qml
-! grep -Fq 'text: "Open install guide"' components/PanelMenu.qml
+refute -Fq 'text: "Install Guides"' components/PanelMenu.qml
+refute -Fq 'text: "Open install guide"' components/PanelMenu.qml
 grep -Fq 'Model.INSTALL_DOCS_URL' components/PanelMenu.qml
 grep -Fq 'text: "Dashboard..."' components/PanelMenu.qml
 grep -Fq 'text: "GitHub..."' components/PanelMenu.qml
 grep -Fq 'text: "Mihoro..."; onActivated: root.openUrl(Model.PROJECT_URL)' components/PanelMenu.qml
 grep -Fq 'text: "Mihoro docs..."' components/PanelMenu.qml
 grep -Fq 'text: "Mihoro..."' components/PanelMenu.qml
-! grep -Fq 'text: "mihoro"' components/PanelMenu.qml
-! grep -Fq 'text: "Mihoro Docs"' components/PanelMenu.qml
-! grep -Fq 'https://wiki.metacubex.one' components/PanelMenu.qml
+refute -Fq 'text: "mihoro"' components/PanelMenu.qml
+refute -Fq 'text: "Mihoro Docs"' components/PanelMenu.qml
+refute -Fq 'https://wiki.metacubex.one' components/PanelMenu.qml
 grep -Fq 'text: "Subscriptions..."' components/PanelMenu.qml
 [[ "$(grep -n 'text: "Install Mihoro..."' components/PanelMenu.qml | cut -d: -f1)" -lt \
    "$(grep -n 'text: "Subscriptions..."' components/PanelMenu.qml | cut -d: -f1)" ]]
@@ -195,7 +206,7 @@ grep -Fq 'text: "Add subscription URL..."' components/SetupCard.qml
 grep -Fq 'onInstallRequested: root.openInstallPage()' Panel.qml
 grep -Fq 'function openInstallationGuide()' Service.qml
 grep -Fq 'Model.installationGuideCommand()' Service.qml
-! grep -Fq 'scripts/install-mihoro' Service.qml
+refute -Fq 'scripts/install-mihoro' Service.qml
 [[ ! -e scripts/install-mihoro ]]
 grep -Fq 'onClicked: mihoro.clearNotice()' Panel.qml
 grep -Fq 'foreground: root.urgent' Panel.qml
@@ -217,7 +228,7 @@ grep -Fq 'root.service.probe.mihoroInstalled ? root.successColor' components/Ins
 grep -Fq 'root.service.probe.mihoroInstalled ? Qt.rgba(root.successColor.r' components/InstallSection.qml
 grep -Fq 'text: root.service.probe.mihoroVersion' components/InstallSection.qml
 grep -Fq 'text: "Open Installation Guide..."' components/InstallSection.qml
-! grep -Fq 'text: "Install Mihoro..."' components/InstallSection.qml
+refute -Fq 'text: "Install Mihoro..."' components/InstallSection.qml
 grep -Fq 'onGuideRequested: mihoro.openInstallationGuide()' Panel.qml
 grep -Fq 'onSubscriptionRequested: root.openSubscriptionPage()' Panel.qml
 grep -Fq 'name: "settings"' components/ModeSection.qml
@@ -230,7 +241,7 @@ grep -Fq 'var s = width / 16' components/ActionIcon.qml
 grep -Fq 'property real strokeScale: 1.4' components/ActionIcon.qml
 grep -Fq 'ctx.lineWidth = Math.max(1, root.strokeScale * s)' components/ActionIcon.qml
 grep -Fq 'for (var i = 0; i < 8; ++i)' components/ActionIcon.qml
-! grep -Eq '#[0-9a-fA-F]{6}' components/ActionIcon.qml
+refute -Eq '#[0-9a-fA-F]{6}' components/ActionIcon.qml
 [[ ! -e components/SettingsIcon.qml ]]
 [[ ! -e components/TrashIcon.qml ]]
 [[ ! -e components/PencilIcon.qml ]]
@@ -243,7 +254,7 @@ grep -Fq 'width: modeControlRow.width - subscriptionButton.width - modeControlRo
 grep -Fq 'delegate: Button {' components/ModeSection.qml
 grep -Fq 'selected: String(modelData.value) === root.mode' components/ModeSection.qml
 grep -Fq 'bordered: true' components/ModeSection.qml
-! grep -Fq 'text: "⚙"' components/ModeSection.qml
+refute -Fq 'text: "⚙"' components/ModeSection.qml
 grep -Fq 'onBackRequested: root.leaveSubscriptionPage()' Panel.qml
 grep -Fq 'if (root.panelPage === 2) root.leaveSubscriptionPage()' Panel.qml
 
@@ -256,9 +267,9 @@ grep -Fq 'text: root.updating ? "Updating…" : "Update"' components/Subscriptio
 grep -Fq 'text: root.service.probe.configPresent ? "Save" : "Save and set up"' components/SubscriptionSection.qml
 grep -Fq 'QQC.TextArea {' components/SubscriptionSection.qml
 grep -Fq 'wrapMode: TextEdit.WrapAnywhere' components/SubscriptionSection.qml
-! grep -Fq 'QQC.TextField {' components/SubscriptionSection.qml
-! grep -Fq 'text: "Show"' components/SubscriptionSection.qml
-! grep -Fq 'text: "Hide"' components/SubscriptionSection.qml
+refute -Fq 'QQC.TextField {' components/SubscriptionSection.qml
+refute -Fq 'text: "Show"' components/SubscriptionSection.qml
+refute -Fq 'text: "Hide"' components/SubscriptionSection.qml
 grep -Fq '"Last updated " + Model.formatAgo' components/SubscriptionSection.qml
 grep -Fq 'id: subscriptionList' components/SubscriptionSection.qml
 grep -Fq 'id: subscriptionActions' components/SubscriptionSection.qml
@@ -284,11 +295,11 @@ grep -Fq 'text: "No subscriptions yet"' components/SubscriptionSection.qml
 # height it was set at, which is what made it look broken beside a drawn icon.
 grep -Fq 'name: "edit"' components/SubscriptionSection.qml
 grep -Fq 'name: "trash"' components/SubscriptionSection.qml
-! grep -Fq 'iconText:' components/SubscriptionSection.qml
+refute -Fq 'iconText:' components/SubscriptionSection.qml
 [[ "$(grep -c 'iconSize: Style.font.icon' components/SubscriptionSection.qml)" -eq 2 ]]
 # Both keep PanelActionButton's own 22px footprint — the row actions are not
 # where the eye should land.
-! grep -Fq 'size: Style.space(2' components/SubscriptionSection.qml
+refute -Fq 'size: Style.space(2' components/SubscriptionSection.qml
 grep -Fq 'onSelectRequested: function(id) { mihoro.selectSubscription(id) }' Panel.qml
 grep -Fq 'onRemoveRequested: function(id) { mihoro.removeSubscription(id) }' Panel.qml
 grep -Fq 'if (id === "") mihoro.addSubscription(name, url)' Panel.qml
@@ -305,11 +316,11 @@ grep -Fq 'root.selectSubscriptionAt(Number(key) - 1)' Panel.qml
 grep -Fq 'root.requestMode("global")' Panel.qml
 grep -Fq 'ToggleSwitch {' Panel.qml
 grep -Fq 'cursorRing: false' Panel.qml
-! grep -Fq 'hasCursor: root.cursorTarget === "power"' Panel.qml
+refute -Fq 'hasCursor: root.cursorTarget === "power"' Panel.qml
 grep -Fq 'text: "Current status: " + mihoro.connection.label' Panel.qml
-! grep -Fq 'text: mihoro.active ? "Stop mihomo" : "Start mihomo"' Panel.qml
-! grep -Fq 'onColor: systemTheme.blue' Panel.qml
-! grep -Fq 'knobOnColor:' Panel.qml
+refute -Fq 'text: mihoro.active ? "Stop mihomo" : "Start mihomo"' Panel.qml
+refute -Fq 'onColor: systemTheme.blue' Panel.qml
+refute -Fq 'knobOnColor:' Panel.qml
 [[ ! -e components/ServiceSwitch.qml ]]
 
 # IPC is how the rest of Omarchy drives the panel.
@@ -359,7 +370,7 @@ PY
 grep -Fq 'function redactUrls' Model.js
 grep -Fq 'function collapseQuoted' Model.js
 grep -Fq 'elide(collapseQuoted(redactUrls(text), 60), 240)' Model.js
-! grep -Fq 'return parsed.name + ": " + parsed.detail' Model.js
+refute -Fq 'return parsed.name + ": " + parsed.detail' Model.js
 
 # Three lines, clamped by Qt against the panel's real width and the reader's own
 # font size. Counting characters here would break the moment either changed.
@@ -374,21 +385,42 @@ grep -Fq 'Model.defaultAgentCommand()' Service.qml
 grep -Fq 'lastErrorKind' Service.qml
 # It opens a terminal workflow rather than completing the action here.
 grep -Fq 'Diagnose...' Panel.qml
+# Nothing keys its own visibility off the button's. QQuickItem propagates
+# `visible` downward — a false parent makes every child read false — so a
+# wrapper that shows itself only when the button is visible latches off the
+# first time the button is hidden and never comes back. It was that wrapper
+# that swallowed the button in the first place.
+refute -Fq 'noticeDiagnose.visible' Panel.qml
+# It is an offer, not the failure; `urgent` belongs to the notice line above it,
+# and it is an ordinary small outline button rather than a bare label.
+python3 - <<'DIAGNOSE'
+import re, sys
+src = open("Panel.qml").read()
+block = re.search(r"id: noticeDiagnose(.*?)onClicked: mihoro\.diagnose", src, re.S)
+if not block:
+    sys.exit("noticeDiagnose block not found")
+body = block.group(1)
+if "root.urgent" in body:
+    sys.exit("the diagnosis button must not be urgent-coloured")
+if "bordered: true" not in body:
+    sys.exit("the diagnosis button is a small outline button")
+print("diagnosis button ok")
+DIAGNOSE
 
 # The output goes to a 0600 file over stdin. The prompt carries paths to it,
 # because --prompt is argv and the process list is world-readable.
 grep -Fq 'Model.failureLogWriteCommand' Service.qml
 grep -Fq 'Model.diagnosePrompt' Service.qml
 grep -Fq 'Model.diagnoseCommand' Service.qml
-! grep -Eq 'diagnosePrompt\([^)]*(_actionOutput|_actionError|remoteConfigUrl)' Service.qml
+refute -Eq 'diagnosePrompt\([^)]*(_actionOutput|_actionError|remoteConfigUrl)' Service.qml
 
 # ---- privacy --------------------------------------------------------------
 
 # The subscription URL and the API secret are credentials. Neither is written
 # anywhere but back into mihoro.toml.
-! grep -rEq 'console\.(log|warn|error).*(secret|remoteConfigUrl|remote_config_url|\.url)' \
+refute -rEq 'console\.(log|warn|error).*(secret|remoteConfigUrl|remote_config_url|\.url)' \
   Panel.qml Service.qml components/*.qml Model.js ClashApi.js MihoroConfig.js Subscriptions.js
 # Clipboard data is written over stdin, never embedded in a command argument.
-! grep -rEq 'execDetached\(.*wl-copy|bash.*wl-copy' Panel.qml Service.qml components/*.qml
+refute -rEq 'execDetached\(.*wl-copy|bash.*wl-copy' Panel.qml Service.qml components/*.qml
 
 echo "panel source tests passed"

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -350,6 +350,38 @@ if problems:
 print("component scoping ok")
 PY
 
+# ---- failure notice and diagnosis -----------------------------------------
+
+# A failure message quotes back the URL mihoro was given and the body it could
+# not parse — a bearer token and several kilobytes, on their way to a notice
+# line. Redaction runs before shortening: eliding first could stop halfway
+# through a token and leave the front of it on screen.
+grep -Fq 'function redactUrls' Model.js
+grep -Fq 'function collapseQuoted' Model.js
+grep -Fq 'elide(collapseQuoted(redactUrls(text), 60), 240)' Model.js
+! grep -Fq 'return parsed.name + ": " + parsed.detail' Model.js
+
+# Three lines, clamped by Qt against the panel's real width and the reader's own
+# font size. Counting characters here would break the moment either changed.
+grep -Fq 'maximumLineCount: 3' Panel.qml
+grep -Fq 'elide: Text.ElideRight' Panel.qml
+
+# The diagnosis is offered only for a failed mihoro command, and only once a
+# default agent exists to open: Omarchy ships without one, and a button that
+# opens nothing explains nothing.
+grep -Fq 'Model.canDiagnose(mihoro.lastErrorKind, mihoro.defaultAgent)' Panel.qml
+grep -Fq 'Model.defaultAgentCommand()' Service.qml
+grep -Fq 'lastErrorKind' Service.qml
+# It opens a terminal workflow rather than completing the action here.
+grep -Fq 'Diagnose...' Panel.qml
+
+# The output goes to a 0600 file over stdin. The prompt carries paths to it,
+# because --prompt is argv and the process list is world-readable.
+grep -Fq 'Model.failureLogWriteCommand' Service.qml
+grep -Fq 'Model.diagnosePrompt' Service.qml
+grep -Fq 'Model.diagnoseCommand' Service.qml
+! grep -Eq 'diagnosePrompt\([^)]*(_actionOutput|_actionError|remoteConfigUrl)' Service.qml
+
 # ---- privacy --------------------------------------------------------------
 
 # The subscription URL and the API secret are credentials. Neither is written


### PR DESCRIPTION
## What was wrong

A failed `mihoro` command was rendered verbatim into the notice line, and mihoro's failures quote back whatever it was handed.

**A subscription that answers with a node list instead of a Clash config.** V2Board-style panels choose their format by `User-Agent` or a `flag` parameter; mihoro sends `mihoro`, which they do not recognise, so the body comes back as base64 nodes and serde quotes all of it into the error. Reproduced against a real subscription in an isolated `HOME`: **6940 bytes on one line**. The notice wraps, so it blows the panel open.

**A plain network error.** mihoro prints the subscription URL — token and all — twice:

```
✗ config: failed to GET from 'https://…/subscribe?token=SECRET123': error sending
request for url (https://…/subscribe?token=SECRET123): client error (Connect): unexpected EOF
```

That is a bearer credential on screen, which `DESIGN.md` says never happens outside the editor.

Root cause of the length: `stageFailureMessage` returned `name + ": " + detail` unelided from the fail branch, while only the fallback branch shortened anything — so a whole response body reached a one-line label.

## What changed

**Shorten before showing, never by the clamp.** `Model.noticeMessage` redacts URLs to their host, collapses quoted runs long enough to be a payload rather than a field name, then caps. Eliding first could stop halfway through a token and leave the front of it on screen. The 6.6 KB case becomes 66 characters:

```
config: invalid type: string "…", expected struct MihomoYamlConfig
```

Short quotes survive — `missing field "proxies"` is the part carrying the meaning.

**Three lines, clamped by `maximumLineCount`** rather than a character count, so it holds against the reader's font size and the panel's real width.

**`Diagnose...`** — three lines still cannot say why a command failed, and the panel can neither read a journal nor fetch a URL to find out. The button writes the whole output to a `0600` file and points the user's default agent at it. It follows `omarchy-crash-watch`:

- checks `omarchy-default-agent` first, because a button that opens nothing explains nothing
- hands over **paths, never the output** — `omarchy-agent --prompt` becomes argv, and the process list is world-readable
- offered only for a failed `mihoro` command; a rejected URL is the user's own to fix
- only on a click — a failed update must not spawn a terminal nobody asked for

Every other error reports through `reportError`, so the offer never outlives the failure it belongs to.

## Not in scope

`mihoro_user_agent` is mihoro's own key. The panel writes `remote_config_url` and leaves the rest of `mihoro.toml` alone, so a subscription needing a Clash format is fixed on the URL (`&flag=clashmeta`) rather than by the panel taking over a key it does not own.

## Testing

`make validate` — exit 0.

New in `tests/test_model.js`: the token and path are gone from a network failure while the host survives; the echoed body is collapsed with both meaningful ends intact and no account UUID; short quotes are left alone; an unquoted run still hits the cap. New in `tests/test_panel_source.sh`: redaction runs before shortening, the three-line clamp, the button gated on both the error kind and a chosen agent, and the prompt never carrying the output. `DESIGN.md` is updated in the same commit, per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)