### PR TITLE
Switch proxy nodes per group, test delays, and toggle TUN

### DIFF
--- a/ClashApi.js
+++ b/ClashApi.js
@@ -260,11 +260,12 @@ function findRoute(body, host) {
 // `Proxy`. Resolve the payload's real key for the wanted name — exact match
 // first, then case-insensitive — so both parsing and switching address the
 // group the core actually has. Null when nothing matches.
-function resolveGroupName(body, wanted) {
-  var payload = parseJson(body)
-  var proxies = payload && payload.proxies && typeof payload.proxies === "object"
-    ? payload.proxies : null
-  if (!proxies) return null
+//
+// Split from `resolveGroupName` so a caller that has already parsed the body
+// does not parse it a second time: `/proxies` is the largest payload the panel
+// reads, and every extra parse is a synchronous cost on the GUI thread.
+function groupKeyIn(proxies, wanted) {
+  if (!proxies || typeof proxies !== "object") return null
   var name = String(wanted || "")
   if (name === "") return null
   if (Object.prototype.hasOwnProperty.call(proxies, name)) return name
@@ -276,11 +277,16 @@ function resolveGroupName(body, wanted) {
   return null
 }
 
+function resolveGroupName(body, wanted) {
+  var payload = parseJson(body)
+  return groupKeyIn(payload ? payload.proxies : null, wanted)
+}
+
 function parseProxyGroup(body, groupName) {
   var payload = parseJson(body)
   if (!payload) return null
   var proxies = payload.proxies
-  var resolved = resolveGroupName(body, groupName)
+  var resolved = groupKeyIn(proxies, groupName)
   var group = resolved !== null ? proxies[resolved] : null
   var all = group && group.all instanceof Array ? group.all : []
   var options = []

--- a/ClashApi.js
+++ b/ClashApi.js
@@ -255,11 +255,33 @@ function findRoute(body, host) {
   return ""
 }
 
+// Group names come from the subscription, and the API's keys and PUT path
+// are case-sensitive: one config's rule group is `PROXY`, another's is
+// `Proxy`. Resolve the payload's real key for the wanted name — exact match
+// first, then case-insensitive — so both parsing and switching address the
+// group the core actually has. Null when nothing matches.
+function resolveGroupName(body, wanted) {
+  var payload = parseJson(body)
+  var proxies = payload && payload.proxies && typeof payload.proxies === "object"
+    ? payload.proxies : null
+  if (!proxies) return null
+  var name = String(wanted || "")
+  if (name === "") return null
+  if (Object.prototype.hasOwnProperty.call(proxies, name)) return name
+  var lower = name.toLowerCase()
+  for (var key in proxies) {
+    if (!Object.prototype.hasOwnProperty.call(proxies, key)) continue
+    if (key.toLowerCase() === lower) return key
+  }
+  return null
+}
+
 function parseProxyGroup(body, groupName) {
   var payload = parseJson(body)
   if (!payload) return null
   var proxies = payload.proxies
-  var group = proxies && typeof proxies === "object" ? proxies[String(groupName || "")] : null
+  var resolved = resolveGroupName(body, groupName)
+  var group = resolved !== null ? proxies[resolved] : null
   var all = group && group.all instanceof Array ? group.all : []
   var options = []
   for (var i = 0; i < all.length; i++) {

--- a/ClashApi.js
+++ b/ClashApi.js
@@ -99,6 +99,32 @@ function selectProxyCommand(base, secret, group, name) {
     .concat([String(base) + "/proxies/" + encodeURIComponent(String(group || ""))])
 }
 
+// Surge-style latency test. mihomo answers one GET with a name → delay map for
+// the whole group, so testing costs one request no matter how many nodes the
+// subscription carries. The URL is mihomo's own default target.
+var DELAY_TEST_URL = "http://www.gstatic.com/generate_204"
+var DELAY_TIMEOUT_MS = "5000"
+
+// The curl cap runs past the delay timeout: a node that hangs is reported as a
+// timeout by the core itself, and only a wedged core should cost the watchdog.
+function groupDelayCommand(base, secret, group) {
+  var query = "?url=" + encodeURIComponent(DELAY_TEST_URL) + "&timeout=" + DELAY_TIMEOUT_MS
+  return ["curl", "-sS", "--max-time", String(Number(DELAY_TIMEOUT_MS) / 1000 + 5), "-w", "\\n%{http_code}"]
+    .concat(authArgs(secret))
+    .concat([String(base) + "/group/" + encodeURIComponent(String(group || "")) + "/delay" + query])
+}
+
+// Runtime-only: PATCH /configs flips the running core's TUN device. mihoro's
+// TOML schema has no tun key, so there is nothing to persist it into — the
+// panel says so rather than pretending a restart keeps it.
+function setTunCommand(base, secret, enable) {
+  return ["curl", "-sS", "--max-time", TIMEOUT_SECONDS, "-w", "\\n%{http_code}",
+          "-X", "PATCH", "-H", "Content-Type: application/json",
+          "-d", JSON.stringify({ tun: { enable: enable === true } })]
+    .concat(authArgs(secret))
+    .concat([String(base) + "/configs"])
+}
+
 // `/traffic` pushes one JSON object per second for as long as the socket is
 // held open, so live speeds cost one long-lived curl while the panel is open
 // instead of a poll loop. `--no-buffer` is what makes each line arrive as it
@@ -210,6 +236,58 @@ function parseGlobalProxies(body) {
     if (name !== "") options.push({ value: name, label: name })
   }
   return { current: group ? String(group.now || "") : "", options: options }
+}
+
+// The last delay the core measured for a node. `history` entries are
+// `{time, delay}`; the core reports a failed probe as delay 0, and a node
+// never probed has no history at all — the two have to stay distinguishable,
+// so the absent case is NaN rather than 0.
+function nodeDelay(entry) {
+  var history = entry && entry.history instanceof Array ? entry.history : []
+  if (history.length === 0) return NaN
+  var last = history[history.length - 1]
+  var delay = Number(last && last.delay)
+  return isFinite(delay) ? delay : NaN
+}
+
+// Every Selector group except GLOBAL — the mode chips own GLOBAL, and listing
+// it here too would give it two pickers that can disagree. `all` names are
+// looked up in the same payload so each node carries its last measured delay.
+function parseSelectorGroups(body) {
+  var payload = parseJson(body)
+  if (!payload) return null
+  var proxies = payload.proxies
+  if (!proxies || typeof proxies !== "object") return null
+  var groups = []
+  for (var key in proxies) {
+    if (!Object.prototype.hasOwnProperty.call(proxies, key)) continue
+    var entry = proxies[key]
+    if (!entry || String(entry.type) !== "Selector" || key === "GLOBAL") continue
+    var all = entry.all instanceof Array ? entry.all : []
+    var nodes = []
+    for (var i = 0; i < all.length; i++) {
+      var name = String(all[i] || "")
+      if (name === "") continue
+      nodes.push({ name: name, delay: nodeDelay(proxies[name]) })
+    }
+    groups.push({ name: String(key), now: String(entry.now || ""), nodes: nodes })
+  }
+  groups.sort(function(a, b) { return a.name < b.name ? -1 : (a.name > b.name ? 1 : 0) })
+  return groups
+}
+
+// `/group/{name}/delay` answers {nodeName: delayMs}. Nodes whose probe failed
+// are absent from the map, so a missing key means timeout, not 0.
+function parseGroupDelay(body) {
+  var payload = parseJson(body)
+  if (!payload) return null
+  var delays = {}
+  for (var key in payload) {
+    if (!Object.prototype.hasOwnProperty.call(payload, key)) continue
+    var delay = Number(payload[key])
+    if (isFinite(delay)) delays[String(key)] = delay
+  }
+  return delays
 }
 
 // `Number(null)` is 0 and `Number("")` is 0, either of which would pass for a

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -94,11 +94,18 @@ credential.
   terminal nobody asked for. It carries the plain foreground, not `urgent`: the
   failure is the notice line above it, and the button is an offer.
 - **Collapsing is not navigation.** A page is always reached by name; a section
-  inside one may still fold. PROXY NODES ships shut: a subscription's groups run
-  three lines each and would push the connection stats off the bottom of the
-  panel for everyone who never changes a node. What a fold hides is a detour,
-  never state the page is accountable for — the node actually carrying traffic
-  stays on the connection row either way.
+  inside one may still fold behind an icon. PROXY NODES ships folded into the
+  icon beside the mode chips: a subscription's groups run three lines each and
+  would push the connection stats off the bottom of the panel for everyone who
+  never changes a node. A folded section leaves nothing on screen, header
+  included. What a fold hides is a detour, never state the page is accountable
+  for — the node actually carrying traffic stays on the connection row either
+  way.
+- **A state change does not sit inside a read-only block.** The connection stats
+  are there to be read, so TUN reports its state there and is switched from the
+  panel menu, where the other actions are. A toggle in that column put a change
+  to the running core one stray click from a block nobody expects to be
+  clickable.
 - **A node switch is staged until `Apply`,** like a local rule and like the mode
   row's own proxy. A picker that switched on selection would fire a PUT at
   whatever its search filter happened to land on while the user was still
@@ -140,17 +147,18 @@ credential.
   order. A panel this shallow does not need per-section cursors. Node groups are
   `node:<group>` targets in that list, so the cursor walks power, modes, nodes,
   and the subscription in the order they are drawn.
-- A section that is collapsed contributes exactly one target — its header, which
-  opens it. Keeping the hidden rows' targets would walk the cursor through rows
-  nobody can see. `nodes` is that target for the proxy nodes; `n` opens the
-  section as well as aiming at it.
+- A folded section contributes no targets at all — not the rows it hides, which
+  would walk the cursor through things nobody can see, and not its own
+  disclosure, which is a right-edge icon and therefore never a target. `n` opens
+  the proxy nodes and lands the cursor on the first group.
 - Right-edge action buttons are not cursor targets; the row they sit in is.
 - Every action the mouse can reach has a key: the letter for the page's own
   actions, digits for a list.
 - An open node picker owns the keys — its search filter accepts every letter the
   panel binds — so the key catcher yields to it as it does to the URL editor.
-- `d` tests the delays of the group under the cursor, and `u` toggles TUN. A
-  pick made while a switch is in flight is queued (latest wins), never dropped.
+- `d` tests the delays of the group under the cursor, and `u` toggles TUN, whose
+  mouse path is the menu row rather than a control on the page. A pick made while
+  a switch is in flight is queued (latest wins), never dropped.
   Enter on a group confirms a drafted pick, or opens the picker when there is
   none, so the keyboard reaches Apply without a key of its own.
 - The poll watchdog reaps polls only. Its fuse is tied to the refresh that armed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -93,6 +93,16 @@ credential.
   explains nothing. It never opens on its own: a failed update must not spawn a
   terminal nobody asked for. It carries the plain foreground, not `urgent`: the
   failure is the notice line above it, and the button is an offer.
+- **Collapsing is not navigation.** A page is always reached by name; a section
+  inside one may still fold. PROXY NODES ships shut: a subscription's groups run
+  three lines each and would push the connection stats off the bottom of the
+  panel for everyone who never changes a node. What a fold hides is a detour,
+  never state the page is accountable for — the node actually carrying traffic
+  stays on the connection row either way.
+- **A node switch is staged until `Apply`,** like a local rule and like the mode
+  row's own proxy. A picker that switched on selection would fire a PUT at
+  whatever its search filter happened to land on while the user was still
+  typing.
 - **A refused or failed action reports on the page it happened on.** A notice
   that only renders on page one turns a rejected subscription switch into the
   panel appearing to ignore the click. That was a real bug.
@@ -130,6 +140,10 @@ credential.
   order. A panel this shallow does not need per-section cursors. Node groups are
   `node:<group>` targets in that list, so the cursor walks power, modes, nodes,
   and the subscription in the order they are drawn.
+- A section that is collapsed contributes exactly one target — its header, which
+  opens it. Keeping the hidden rows' targets would walk the cursor through rows
+  nobody can see. `nodes` is that target for the proxy nodes; `n` opens the
+  section as well as aiming at it.
 - Right-edge action buttons are not cursor targets; the row they sit in is.
 - Every action the mouse can reach has a key: the letter for the page's own
   actions, digits for a list.
@@ -137,6 +151,8 @@ credential.
   panel binds — so the key catcher yields to it as it does to the URL editor.
 - `d` tests the delays of the group under the cursor, and `u` toggles TUN. A
   pick made while a switch is in flight is queued (latest wins), never dropped.
+  Enter on a group confirms a drafted pick, or opens the picker when there is
+  none, so the keyboard reaches Apply without a key of its own.
 - The poll watchdog reaps polls only. Its fuse is tied to the refresh that armed
   it, so reaping an action from it could kill a healthy delay test mid-flight;
   actions bound themselves with curl's `--max-time` instead.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -109,6 +109,11 @@ credential.
   actions, digits for a list.
 - An open node picker owns the keys — its search filter accepts every letter the
   panel binds — so the key catcher yields to it as it does to the URL editor.
+- `d` tests the delays of the group under the cursor, and `u` toggles TUN. A
+  pick made while a switch is in flight is queued (latest wins), never dropped.
+- The poll watchdog reaps polls only. Its fuse is tied to the refresh that armed
+  it, so reaping an action from it could kill a healthy delay test mid-flight;
+  actions bound themselves with curl's `--max-time` instead.
 
 ## Credentials
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,6 +44,9 @@ edit.
   properties, so one theme change reaches every view.
 - The semantics are fixed: `Color.accent` is download, connected, and the
   current selection; `Color.urgent` is upload, failure, and destruction.
+  Node delays are the one place theme green and yellow appear (through
+  `SystemTheme`): fast and slow. The milliseconds or `timeout` are always
+  printed beside the colour, so the value never rides on the colour alone.
 - **Colour alone never carries state.** The selected subscription is a filled
   dot *and* a selected fill; some themes put the accent close to the foreground.
 
@@ -98,10 +101,14 @@ credential.
   visuals derive from `hasCursor` / `current`. That is what keeps exactly one
   highlight on screen whichever input is driving.
 - The panel keeps one flat list of targets rebuilt from service state, in screen
-  order. A panel this shallow does not need per-section cursors.
+  order. A panel this shallow does not need per-section cursors. Node groups are
+  `node:<group>` targets in that list, so the cursor walks power, modes, nodes,
+  and the subscription in the order they are drawn.
 - Right-edge action buttons are not cursor targets; the row they sit in is.
 - Every action the mouse can reach has a key: the letter for the page's own
   actions, digits for a list.
+- An open node picker owns the keys — its search filter accepts every letter the
+  panel binds — so the key catcher yields to it as it does to the URL editor.
 
 ## Credentials
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ QML_FILES := Panel.qml Service.qml \
 	components/StatRow.qml \
 	components/Sparkline.qml \
 	components/ModeSection.qml \
+	components/NodesSection.qml \
 	components/ConnectionSection.qml \
 	components/SubscriptionSection.qml \
 	components/InstallSection.qml \

--- a/Model.js
+++ b/Model.js
@@ -517,12 +517,28 @@ function formatDelay(ms) {
   return String(Math.round(Number(ms))) + "ms"
 }
 
+// An array that crossed a QML delegate boundary (Repeater/Instantiator
+// modelData) arrives as a sequence wrapper: `length` and indexing work, and
+// `instanceof Array` is even true, but `Array.isArray` is false — it is not
+// a real JS array. `instanceof` in turn fails across realms (the tests load
+// this file into a vm context). Neither type check holds everywhere, so copy
+// by length instead of asking what the value is.
+function toArray(value) {
+  if (Array.isArray(value)) return value.slice()
+  if (!value || typeof value !== "object") return []
+  var count = Number(value.length)
+  if (!isFinite(count) || count < 0) return []
+  var out = []
+  for (var i = 0; i < count; i++) out.push(value[i])
+  return out
+}
+
 // Measured nodes fastest-first, then the never-probed, then timeouts: the
 // order someone picking a node actually wants. Ties keep the subscription's
 // own order, so the list does not shuffle between refreshes that measure
 // nothing new.
 function sortNodesByDelay(nodes) {
-  var list = Array.isArray(nodes) ? nodes.slice() : []
+  var list = toArray(nodes)
   function rank(node) {
     var state = delayState(node && node.delay)
     return state === "fast" || state === "slow" ? 0 : state === "unknown" ? 1 : 2

--- a/Model.js
+++ b/Model.js
@@ -495,6 +495,56 @@ function sparkline(history, capacity, scalePeak) {
   return { points: points, lead: lead, peak: peak }
 }
 
+// ------------------------------------------------------------- node delays
+//
+// Surge-style reading of a delay: fast nodes are green, slow ones stand out,
+// and a failed probe is not a fast node. mihomo reports a failed probe as
+// delay 0, so 0 means timeout — a node never probed is NaN and stays "unknown".
+
+var DELAY_FAST_MS = 800
+
+function delayState(ms) {
+  var delay = Number(ms)
+  if (!isFinite(delay)) return "unknown"
+  if (delay <= 0) return "timeout"
+  return delay <= DELAY_FAST_MS ? "fast" : "slow"
+}
+
+function formatDelay(ms) {
+  var state = delayState(ms)
+  if (state === "unknown") return "—"
+  if (state === "timeout") return "timeout"
+  return String(Math.round(Number(ms))) + "ms"
+}
+
+// Measured nodes fastest-first, then the never-probed, then timeouts: the
+// order someone picking a node actually wants. Ties keep the subscription's
+// own order, so the list does not shuffle between refreshes that measure
+// nothing new.
+function sortNodesByDelay(nodes) {
+  var list = Array.isArray(nodes) ? nodes.slice() : []
+  function rank(node) {
+    var state = delayState(node && node.delay)
+    return state === "fast" || state === "slow" ? 0 : state === "unknown" ? 1 : 2
+  }
+  var decorated = []
+  for (var i = 0; i < list.length; i++) decorated.push({ index: i, node: list[i] })
+  decorated.sort(function(a, b) {
+    var ra = rank(a.node)
+    var rb = rank(b.node)
+    if (ra !== rb) return ra - rb
+    if (ra === 0) {
+      var da = Number(a.node.delay)
+      var db = Number(b.node.delay)
+      if (da !== db) return da - db
+    }
+    return a.index - b.index
+  })
+  var sorted = []
+  for (var j = 0; j < decorated.length; j++) sorted.push(decorated[j].node)
+  return sorted
+}
+
 // ---------------------------------------------------------------- formatting
 
 // Binary units, named as binary units. The arithmetic below divides by 1024,

--- a/Panel.qml
+++ b/Panel.qml
@@ -54,18 +54,11 @@ Panel {
     if (!mihoro.initialized) return ["setup"]
     var list = ["power"]
     if (mihoro.canSwitchMode) list.push("mode")
-    // Shut, the nodes section is one target that opens it; open, each group
-    // is its own. Keeping the group targets while they are hidden would walk
-    // the cursor through rows nobody can see.
-    if (mihoro.proxyGroups.length > 0) {
-      list.push("nodes")
-      if (nodesExpanded)
-        for (var i = 0; i < mihoro.proxyGroups.length; i++) list.push("node:" + mihoro.proxyGroups[i].name)
-    }
-    // Only while the core answers: the switch is inert otherwise, and an inert
-    // target is a place the cursor lands and nothing happens.
-    if (mihoro.liveConfigs && mihoro.liveConfigs.tunEnabled !== null
-        && mihoro.connection.key === "running") list.push("tun")
+    // Only the groups on screen: the section is opened from the mode row's
+    // icon, and keeping targets for hidden rows would walk the cursor through
+    // rows nobody can see.
+    if (nodesExpanded)
+      for (var i = 0; i < mihoro.proxyGroups.length; i++) list.push("node:" + mihoro.proxyGroups[i].name)
     list.push("subscription")
     return list
   }
@@ -120,9 +113,7 @@ Panel {
     var target = cursorTarget
     if (target === "power") mihoro.toggleService()
     else if (target === "mode") root.requestMode(Model.MODES[modeCursor].value)
-    else if (target === "nodes") root.nodesExpanded = !root.nodesExpanded
     else if (target.indexOf("node:") === 0) nodesSection.activateGroup(target.substring(5))
-    else if (target === "tun") mihoro.toggleTun()
     else if (target === "subscription") root.openSubscriptionPage()
     else if (target.indexOf("sub:") === 0) mihoro.selectSubscription(target.substring(4))
     else if (target === "add") subscription.beginAdd()
@@ -492,6 +483,9 @@ Panel {
                 canOpenRules: mihoro.activeSubscriptionId !== "" && mihoro.rulesLoaded
                   && !mihoro.applying
                 canTestRoutes: mihoro.initialized && mihoro.serviceActive && mihoro.apiState === "ok"
+                canToggleTun: mihoro.canToggleTun
+                tunEnabled: mihoro.tunState === true
+                onTunRequested: mihoro.toggleTun()
                 onRestartRequested: mihoro.restartService()
                 onCopyProxyRequested: mihoro.copyProxyExport()
                 onInstallRequested: root.openInstallPage()
@@ -620,6 +614,9 @@ Panel {
             onGlobalRequested: mihoro.refreshProxies()
             onProxyRequested: function(value) { mihoro.selectGlobalProxy(value) }
             onSubscriptionRequested: root.openSubscriptionPage()
+            nodesAvailable: mihoro.proxyGroups.length > 0
+            nodesExpanded: root.nodesExpanded
+            onNodesToggleRequested: root.nodesExpanded = !root.nodesExpanded
             onChipHovered: function(index, isHovered) {
               if (!isHovered) {
                 if (root.cursorTarget === "mode") root.cursorActive = false
@@ -633,13 +630,14 @@ Panel {
           }
 
           PanelSeparator {
-            visible: root.panelPage === 1 && mihoro.initialized && mihoro.proxyGroups.length > 0
+            visible: nodesSection.visible
             foreground: root.foreground
           }
 
           NodesSection {
             id: nodesSection
-            visible: root.panelPage === 1 && mihoro.initialized && mihoro.proxyGroups.length > 0
+            visible: root.panelPage === 1 && mihoro.initialized
+              && mihoro.proxyGroups.length > 0 && root.nodesExpanded
             width: parent.width
             textColor: root.foreground
             panelFontFamily: root.fontFamily
@@ -650,18 +648,9 @@ Panel {
             testingGroup: mihoro.testingDelayGroup
             switchable: mihoro.connection.key === "running"
             cursorIndex: root.nodeCursorIndex
-            headerCursor: root.cursorTarget === "nodes"
             expanded: root.nodesExpanded
             onNodeRequested: function(group, name) { mihoro.selectNode(group, name) }
             onTestRequested: function(group) { mihoro.testGroupDelay(group) }
-            onToggleRequested: root.nodesExpanded = !root.nodesExpanded
-            onHeaderHovered: function(isHovered) {
-              if (!isHovered) return
-              var index = root.targets.indexOf("nodes")
-              if (index < 0) return
-              root.cursorActive = true
-              root.cursorIndex = index
-            }
             onDropdownHovered: function(index, isHovered) {
               if (!isHovered) return
               if (mihoro.proxyGroups.length === 0) return
@@ -681,14 +670,6 @@ Panel {
             service: mihoro
             textColor: root.foreground
             panelFontFamily: root.fontFamily
-            tunCursor: root.cursorTarget === "tun"
-            onTunHovered: function(isHovered) {
-              if (!isHovered) return
-              var index = root.targets.indexOf("tun")
-              if (index < 0) return
-              root.cursorActive = true
-              root.cursorIndex = index
-            }
           }
 
           SubscriptionSection {

--- a/Panel.qml
+++ b/Panel.qml
@@ -47,6 +47,7 @@ Panel {
     var list = ["power"]
     if (mihoro.canSwitchMode) list.push("mode")
     for (var i = 0; i < mihoro.proxyGroups.length; i++) list.push("node:" + mihoro.proxyGroups[i].name)
+    if (mihoro.liveConfigs && mihoro.liveConfigs.tunEnabled !== null) list.push("tun")
     list.push("subscription")
     return list
   }
@@ -102,6 +103,7 @@ Panel {
     if (target === "power") mihoro.toggleService()
     else if (target === "mode") root.requestMode(Model.MODES[modeCursor].value)
     else if (target.indexOf("node:") === 0) nodesSection.openGroup(target.substring(5))
+    else if (target === "tun") mihoro.toggleTun()
     else if (target === "subscription") root.openSubscriptionPage()
     else if (target.indexOf("sub:") === 0) mihoro.selectSubscription(target.substring(4))
     else if (target === "add") subscription.beginAdd()
@@ -332,6 +334,12 @@ Panel {
         else if (root.panelPage === 1 && key === "r") mihoro.refresh()
         else if (root.panelPage === 1 && key === "s") root.openSubscriptionPage()
         else if (root.panelPage === 1 && key === "n") root.focusNodes()
+        else if (root.panelPage === 1 && key === "u") mihoro.toggleTun()
+        else if (root.panelPage === 1 && key === "d") {
+          // Tests the group under the cursor; with the cursor elsewhere there
+          // is nothing to aim the test at.
+          if (root.cursorTarget.indexOf("node:") === 0) mihoro.testGroupDelay(root.cursorTarget.substring(5))
+        }
         else if (root.panelPage === 1 && key === "i") root.openInstallPage()
         else if (root.panelPage === 1 && key === "m") root.cycleMode(1)
         else if (root.panelPage === 1 && key === "1") root.requestMode("rule")
@@ -576,6 +584,7 @@ Panel {
             groups: mihoro.proxyGroups
             pendingNode: mihoro.pendingNode
             testingGroup: mihoro.testingDelayGroup
+            switchable: mihoro.connection.key === "running"
             cursorIndex: root.nodeCursorIndex
             onNodeRequested: function(group, name) { mihoro.selectNode(group, name) }
             onTestRequested: function(group) { mihoro.testGroupDelay(group) }
@@ -598,6 +607,14 @@ Panel {
             service: mihoro
             textColor: root.foreground
             panelFontFamily: root.fontFamily
+            tunCursor: root.cursorTarget === "tun"
+            onTunHovered: function(isHovered) {
+              if (!isHovered) return
+              var index = root.targets.indexOf("tun")
+              if (index < 0) return
+              root.cursorActive = true
+              root.cursorIndex = index
+            }
           }
 
           SubscriptionSection {

--- a/Panel.qml
+++ b/Panel.qml
@@ -46,8 +46,21 @@ Panel {
     if (!mihoro.initialized) return ["setup"]
     var list = ["power"]
     if (mihoro.canSwitchMode) list.push("mode")
+    for (var i = 0; i < mihoro.proxyGroups.length; i++) list.push("node:" + mihoro.proxyGroups[i].name)
     list.push("subscription")
     return list
+  }
+
+  // Which group's picker the cursor is on, or -1. Group targets are named
+  // "node:<group>" so one flat list keeps power, modes, nodes, and the
+  // subscription in screen order.
+  readonly property int nodeCursorIndex: {
+    var target = cursorTarget
+    if (target.indexOf("node:") !== 0) return -1
+    var name = target.substring(5)
+    for (var i = 0; i < mihoro.proxyGroups.length; i++)
+      if (mihoro.proxyGroups[i].name === name) return i
+    return -1
   }
 
   readonly property string cursorTarget: {
@@ -88,6 +101,7 @@ Panel {
     var target = cursorTarget
     if (target === "power") mihoro.toggleService()
     else if (target === "mode") root.requestMode(Model.MODES[modeCursor].value)
+    else if (target.indexOf("node:") === 0) nodesSection.openGroup(target.substring(5))
     else if (target === "subscription") root.openSubscriptionPage()
     else if (target.indexOf("sub:") === 0) mihoro.selectSubscription(target.substring(4))
     else if (target === "add") subscription.beginAdd()
@@ -160,6 +174,16 @@ Panel {
     root.requestMode(Model.MODES[next].value)
   }
 
+  function focusNodes() {
+    for (var i = 0; i < targets.length; i++) {
+      if (String(targets[i]).indexOf("node:") === 0) {
+        cursorActive = true
+        cursorIndex = i
+        return
+      }
+    }
+  }
+
   Service {
     id: mihoro
     settings: root.settings
@@ -194,6 +218,11 @@ Panel {
       if (!Model.MODES.some(function(entry) { return entry.value === String(value).toLowerCase() }))
         return "expected one of rule, global, direct"
       mihoro.setMode(String(value).toLowerCase())
+      return "ok"
+    }
+    function node(group: string, name: string): string {
+      if (String(group) === "" || String(name) === "") return "expected a group and a node name"
+      mihoro.selectNode(String(group), String(name))
       return "ok"
     }
     function status(): string {
@@ -277,9 +306,10 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
-      // While the URL editor is open every key belongs to it, including the
-      // panel's single-letter shortcuts — a URL contains `r` and `u`.
-      blocked: subscription.editing
+      // While the URL editor or a node picker is open every key belongs to
+      // it, including the panel's single-letter shortcuts — a URL contains
+      // `r` and `u`, and a node filter can contain any of them.
+      blocked: subscription.editing || nodesSection.searchOpen
 
       onMoveRequested: function(dx, dy) {
         if (!root.cursorActive) { root.cursorActive = true; return }
@@ -301,6 +331,7 @@ Panel {
         else if (root.panelPage === 1 && key === "t") mihoro.toggleService()
         else if (root.panelPage === 1 && key === "r") mihoro.refresh()
         else if (root.panelPage === 1 && key === "s") root.openSubscriptionPage()
+        else if (root.panelPage === 1 && key === "n") root.focusNodes()
         else if (root.panelPage === 1 && key === "i") root.openInstallPage()
         else if (root.panelPage === 1 && key === "m") root.cycleMode(1)
         else if (root.panelPage === 1 && key === "1") root.requestMode("rule")
@@ -526,6 +557,33 @@ Panel {
               root.cursorActive = true
               root.cursorIndex = root.targets.indexOf("mode")
               root.modeCursor = index
+            }
+          }
+
+          PanelSeparator {
+            visible: root.panelPage === 1 && mihoro.initialized && mihoro.proxyGroups.length > 0
+            foreground: root.foreground
+          }
+
+          NodesSection {
+            id: nodesSection
+            visible: root.panelPage === 1 && mihoro.initialized && mihoro.proxyGroups.length > 0
+            width: parent.width
+            textColor: root.foreground
+            panelFontFamily: root.fontFamily
+            fastColor: systemTheme.green
+            slowColor: systemTheme.yellow
+            groups: mihoro.proxyGroups
+            pendingNode: mihoro.pendingNode
+            testingGroup: mihoro.testingDelayGroup
+            cursorIndex: root.nodeCursorIndex
+            onNodeRequested: function(group, name) { mihoro.selectNode(group, name) }
+            onTestRequested: function(group) { mihoro.testGroupDelay(group) }
+            onDropdownHovered: function(index, isHovered) {
+              if (!isHovered) return
+              if (mihoro.proxyGroups.length === 0) return
+              root.cursorActive = true
+              root.cursorIndex = root.targets.indexOf("node:" + mihoro.proxyGroups[index].name)
             }
           }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -27,6 +27,12 @@ Panel {
   property int modeCursor: 0
   property int panelPage: 1
 
+  // Whether the nodes section is open. It lives here, not in the section: the
+  // cursor target list is built before that object exists, and it is what
+  // decides whether the groups are in it. Closed on every panel open — the
+  // section is a detour, not the panel's subject.
+  property bool nodesExpanded: false
+
   // One flat list of what the keyboard can reach, rebuilt from the service
   // state. A panel this shallow does not need per-section cursors: the order
   // here is the order on screen.
@@ -48,8 +54,18 @@ Panel {
     if (!mihoro.initialized) return ["setup"]
     var list = ["power"]
     if (mihoro.canSwitchMode) list.push("mode")
-    for (var i = 0; i < mihoro.proxyGroups.length; i++) list.push("node:" + mihoro.proxyGroups[i].name)
-    if (mihoro.liveConfigs && mihoro.liveConfigs.tunEnabled !== null) list.push("tun")
+    // Shut, the nodes section is one target that opens it; open, each group
+    // is its own. Keeping the group targets while they are hidden would walk
+    // the cursor through rows nobody can see.
+    if (mihoro.proxyGroups.length > 0) {
+      list.push("nodes")
+      if (nodesExpanded)
+        for (var i = 0; i < mihoro.proxyGroups.length; i++) list.push("node:" + mihoro.proxyGroups[i].name)
+    }
+    // Only while the core answers: the switch is inert otherwise, and an inert
+    // target is a place the cursor lands and nothing happens.
+    if (mihoro.liveConfigs && mihoro.liveConfigs.tunEnabled !== null
+        && mihoro.connection.key === "running") list.push("tun")
     list.push("subscription")
     return list
   }
@@ -104,7 +120,8 @@ Panel {
     var target = cursorTarget
     if (target === "power") mihoro.toggleService()
     else if (target === "mode") root.requestMode(Model.MODES[modeCursor].value)
-    else if (target.indexOf("node:") === 0) nodesSection.openGroup(target.substring(5))
+    else if (target === "nodes") root.nodesExpanded = !root.nodesExpanded
+    else if (target.indexOf("node:") === 0) nodesSection.activateGroup(target.substring(5))
     else if (target === "tun") mihoro.toggleTun()
     else if (target === "subscription") root.openSubscriptionPage()
     else if (target.indexOf("sub:") === 0) mihoro.selectSubscription(target.substring(4))
@@ -213,7 +230,11 @@ Panel {
     root.requestMode(Model.MODES[next].value)
   }
 
+  // `n` opens the section as well as aiming at it: with it shut there is
+  // nothing to put the cursor on but the header the key just acted on.
   function focusNodes() {
+    if (mihoro.proxyGroups.length === 0) return
+    nodesExpanded = true
     for (var i = 0; i < targets.length; i++) {
       if (String(targets[i]).indexOf("node:") === 0) {
         cursorActive = true
@@ -232,6 +253,7 @@ Panel {
   onOpenedChanged: if (opened) {
     subscription.cancelEdit()
     panelPage = 1
+    nodesExpanded = false
     cursorActive = false
     cursorIndex = 0
     modeCursor = Model.modeIndex(mihoro.mode)
@@ -628,8 +650,18 @@ Panel {
             testingGroup: mihoro.testingDelayGroup
             switchable: mihoro.connection.key === "running"
             cursorIndex: root.nodeCursorIndex
+            headerCursor: root.cursorTarget === "nodes"
+            expanded: root.nodesExpanded
             onNodeRequested: function(group, name) { mihoro.selectNode(group, name) }
             onTestRequested: function(group) { mihoro.testGroupDelay(group) }
+            onToggleRequested: root.nodesExpanded = !root.nodesExpanded
+            onHeaderHovered: function(isHovered) {
+              if (!isHovered) return
+              var index = root.targets.indexOf("nodes")
+              if (index < 0) return
+              root.cursorActive = true
+              root.cursorIndex = index
+            }
             onDropdownHovered: function(index, isHovered) {
               if (!isHovered) return
               if (mihoro.proxyGroups.length === 0) return

--- a/README.md
+++ b/README.md
@@ -6,7 +6,18 @@ Mihomo CLI client for Linux.
 <img width="320" alt="Mihoro for Omarchy" src="https://github.com/user-attachments/assets/f58b161e-389e-43bc-880a-8216c67eb863" />
 
 Use it to monitor your proxy, switch between Rule, Global, and Direct modes,
-and keep several subscriptions to switch between.
+pick a proxy node per group with measured delays, toggle TUN, and keep several
+subscriptions to switch between.
+
+## Features
+
+- Connection status, live up/down speed, and a one-minute traffic history
+- Rule / Global / Direct switching against the running core
+- Per-group proxy-node switching (`proxy-node` style): each selector group's
+  nodes with their last delay, a test button for fresh measurements, and
+  fastest-first ordering — press `n` in the panel to jump there
+- TUN toggle (runtime only; a restart restores `config.yaml`)
+- Multiple subscription URLs with switching and updates
 
 ## Requirements
 

--- a/Service.qml
+++ b/Service.qml
@@ -67,6 +67,11 @@ Item {
   property string testingDelayGroup: ""
   property var ruleProxyOptions: []
   property string currentRuleProxy: ""
+  // The rule group as the core actually names it — usually `PROXY`, but the
+  // name comes from the subscription and some ship `Proxy`. Resolved from
+  // every /proxies payload; the PUT path is case-sensitive, so switching
+  // must use this, not a literal.
+  property string ruleProxyGroup: "PROXY"
   property var routeOptions: [
     { value: "DIRECT", label: "DIRECT" },
     { value: "REJECT", label: "REJECT" }
@@ -160,7 +165,7 @@ Item {
   // agree except in the window between a switch and the next refresh.
   readonly property string mode: pendingMode !== "" ? pendingMode
     : (liveConfigs && liveConfigs.mode !== "" ? liveConfigs.mode : config.mode)
-  readonly property string currentProxyGroup: mode === "rule" ? "PROXY"
+  readonly property string currentProxyGroup: mode === "rule" ? ruleProxyGroup
     : (mode === "global" ? "GLOBAL" : "")
   readonly property var currentModeProxyOptions: mode === "rule" ? ruleProxyOptions
     : (mode === "global" ? globalProxyOptions : [])
@@ -1036,6 +1041,8 @@ Item {
       var result = ClashApi.classify(exitCode, proxiesOut.text, proxiesErr.text)
       if (!result.ok) return
       var globalGroup = ClashApi.parseProxyGroup(result.body, "GLOBAL")
+      var ruleGroupName = ClashApi.resolveGroupName(result.body, "PROXY")
+      if (ruleGroupName !== null) root.ruleProxyGroup = ruleGroupName
       var ruleGroup = ClashApi.parseProxyGroup(result.body, "PROXY")
       if (!globalGroup || !ruleGroup) return
       root.globalProxyOptions = globalGroup.options
@@ -1080,7 +1087,7 @@ Item {
       var selectedGroup = root.pendingProxyGroup
       var activateGlobal = root.globalSelectionRequested
       if (root.pendingModeProxy !== "") {
-        if (selectedGroup === "PROXY") root.currentRuleProxy = root.pendingModeProxy
+        if (selectedGroup === root.ruleProxyGroup) root.currentRuleProxy = root.pendingModeProxy
         else if (selectedGroup === "GLOBAL") root.currentGlobalProxy = root.pendingModeProxy
       }
       if (selected !== "") root.currentGlobalProxy = selected

--- a/Service.qml
+++ b/Service.qml
@@ -57,6 +57,11 @@ Item {
   property var trafficAnchor: null
   property var globalProxyOptions: []
   property string currentGlobalProxy: ""
+  // Selector groups other than GLOBAL (which the mode chips own), each with
+  // its nodes and their last measured delay. Filled from the same `/proxies`
+  // payload as the global options.
+  property var proxyGroups: []
+  property string testingDelayGroup: ""
 
   // ---- in-flight intent
   //
@@ -66,6 +71,10 @@ Item {
   property int desiredActive: -1
   property string pendingMode: ""
   property string pendingGlobalProxy: ""
+  // The node switch in flight, as `{group, name}`; null when nothing is.
+  property var pendingNode: null
+  // The TUN state asked for but not yet confirmed by a refresh; -1 means none.
+  property int pendingTun: -1
   property bool globalSelectionRequested: false
   property string actionKind: ""
   property string actionStatus: ""
@@ -222,6 +231,42 @@ Item {
   function cancelGlobalSelection() {
     globalSelectionRequested = false
     pendingGlobalProxy = ""
+  }
+
+  // Same endpoint as the GLOBAL picker, aimed at any Selector group — what
+  // `proxy-node` does from a terminal. The dropdown moves at once and a
+  // refresh confirms, exactly like a mode switch.
+  function selectNode(group, name) {
+    var wantedGroup = String(group || "")
+    var wantedName = String(name || "")
+    if (wantedGroup === "" || wantedName === "" || !canSwitchMode) return
+    if (nodeSelectProcess.running) return
+    pendingNode = { group: wantedGroup, name: wantedName }
+    lastError = ""
+    nodeSelectProcess.command = ClashApi.selectProxyCommand(apiBase, config.secret, wantedGroup, wantedName)
+    nodeSelectProcess.running = true
+  }
+
+  function testGroupDelay(group) {
+    var wanted = String(group || "")
+    if (wanted === "" || apiBase === "" || !serviceActive || delayProcess.running) return
+    testingDelayGroup = wanted
+    lastError = ""
+    delayProcess.command = ClashApi.groupDelayCommand(apiBase, config.secret, wanted)
+    delayProcess.running = true
+  }
+
+  // Runtime-only: the PATCH flips the running core's TUN device, and mihoro's
+  // TOML has no tun key to persist it into, so a restart restores whatever the
+  // generated config.yaml says. The toggle is offered only when the live core
+  // reports a tun field at all.
+  function toggleTun() {
+    if (connection.key !== "running" || tunProcess.running) return
+    if (!liveConfigs || liveConfigs.tunEnabled === null) return
+    pendingTun = liveConfigs.tunEnabled ? 0 : 1
+    lastError = ""
+    tunProcess.command = ClashApi.setTunCommand(apiBase, config.secret, pendingTun === 1)
+    tunProcess.running = true
   }
 
   function toggleService() {
@@ -586,6 +631,9 @@ Item {
       if (connectionsProcess.running) connectionsProcess.running = false
       if (proxiesProcess.running) proxiesProcess.running = false
       if (subscriptionsReadProcess.running) subscriptionsReadProcess.running = false
+      if (nodeSelectProcess.running) nodeSelectProcess.running = false
+      if (delayProcess.running) delayProcess.running = false
+      if (tunProcess.running) tunProcess.running = false
     }
   }
 
@@ -721,6 +769,8 @@ Item {
       root.liveConfigs = parsed
       // The core has spoken; stop overriding with the click.
       if (root.pendingMode !== "" && parsed.mode === root.pendingMode) root.pendingMode = ""
+      if (root.pendingTun !== -1 && parsed.tunEnabled !== null
+          && (parsed.tunEnabled === true) === (root.pendingTun === 1)) root.pendingTun = -1
     }
   }
 
@@ -754,6 +804,19 @@ Item {
       if (!parsed) return
       root.globalProxyOptions = parsed.options
       root.currentGlobalProxy = parsed.current
+      var groups = ClashApi.parseSelectorGroups(result.body)
+      if (groups) {
+        root.proxyGroups = groups
+        // The core has spoken; stop overriding with the click.
+        if (root.pendingNode !== null) {
+          for (var i = 0; i < groups.length; i++) {
+            if (groups[i].name === root.pendingNode.group && groups[i].now === root.pendingNode.name) {
+              root.pendingNode = null
+              break
+            }
+          }
+        }
+      }
     }
   }
 
@@ -783,6 +846,81 @@ Item {
         }
       }
       root.refreshProxies()
+    }
+  }
+
+  Process {
+    id: nodeSelectProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: nodeSelectOut; waitForEnd: true }
+    stderr: StdioCollector { id: nodeSelectErr; waitForEnd: true }
+    onExited: function(exitCode) {
+      var result = ClashApi.classify(exitCode, nodeSelectOut.text, nodeSelectErr.text)
+      if (!result.ok) {
+        root.pendingNode = null
+        root.reportError(result.message)
+        return
+      }
+      var pending = root.pendingNode
+      if (pending !== null) {
+        root.actionStatus = pending.group + " → " + pending.name
+        actionStatusTimer.restart()
+      }
+      root.pendingNode = null
+      root.refreshProxies()
+    }
+  }
+
+  Process {
+    id: delayProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: delayOut; waitForEnd: true }
+    stderr: StdioCollector { id: delayErr; waitForEnd: true }
+    onExited: function(exitCode) {
+      var group = root.testingDelayGroup
+      root.testingDelayGroup = ""
+      var result = ClashApi.classify(exitCode, delayOut.text, delayErr.text)
+      if (!result.ok) {
+        root.reportError(result.message)
+        return
+      }
+      var delays = ClashApi.parseGroupDelay(result.body)
+      if (!delays) return
+      // Absent from the map means the probe failed, and mihomo records that
+      // as delay 0 — write the same value so the two paths agree.
+      var groups = root.proxyGroups.slice()
+      for (var i = 0; i < groups.length; i++) {
+        if (groups[i].name !== group) continue
+        var nodes = groups[i].nodes.slice()
+        for (var j = 0; j < nodes.length; j++)
+          nodes[j] = { name: nodes[j].name, delay: delays[nodes[j].name] !== undefined ? delays[nodes[j].name] : 0 }
+        groups[i] = { name: groups[i].name, now: groups[i].now, nodes: nodes }
+        break
+      }
+      root.proxyGroups = groups
+      root.actionStatus = "Delays updated."
+      actionStatusTimer.restart()
+    }
+  }
+
+  Process {
+    id: tunProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: tunOut; waitForEnd: true }
+    stderr: StdioCollector { id: tunErr; waitForEnd: true }
+    onExited: function(exitCode) {
+      var result = ClashApi.classify(exitCode, tunOut.text, tunErr.text)
+      if (!result.ok) {
+        root.pendingTun = -1
+        root.reportError(result.message)
+        return
+      }
+      root.actionStatus = root.pendingTun === 1 ? "TUN enabled." : "TUN disabled."
+      actionStatusTimer.restart()
+      root.refreshApi()
     }
   }
 

--- a/Service.qml
+++ b/Service.qml
@@ -234,22 +234,36 @@ Item {
   }
 
   // Same endpoint as the GLOBAL picker, aimed at any Selector group — what
-  // `proxy-node` does from a terminal. The dropdown moves at once and a
-  // refresh confirms, exactly like a mode switch.
+  // `proxy-node` does from a terminal. Unlike a mode switch there is no
+  // `mihoro apply` fallback, so this runs only while the API actually answers;
+  // a stale picker against a dead API would just burn curl's timeout and
+  // report an error. A second pick while one is in flight is queued rather
+  // than dropped — latest wins, because that is where the user's eye is.
+  property var _queuedNode: null
+
   function selectNode(group, name) {
     var wantedGroup = String(group || "")
     var wantedName = String(name || "")
-    if (wantedGroup === "" || wantedName === "" || !canSwitchMode) return
-    if (nodeSelectProcess.running) return
+    if (wantedGroup === "" || wantedName === "") return
+    if (connection.key !== "running") return
+    if (nodeSelectProcess.running) {
+      _queuedNode = { group: wantedGroup, name: wantedName }
+      return
+    }
+    startNodeSelect(wantedGroup, wantedName)
+  }
+
+  function startNodeSelect(wantedGroup, wantedName) {
     pendingNode = { group: wantedGroup, name: wantedName }
     lastError = ""
+    optimismTimer.restart()
     nodeSelectProcess.command = ClashApi.selectProxyCommand(apiBase, config.secret, wantedGroup, wantedName)
     nodeSelectProcess.running = true
   }
 
   function testGroupDelay(group) {
     var wanted = String(group || "")
-    if (wanted === "" || apiBase === "" || !serviceActive || delayProcess.running) return
+    if (wanted === "" || connection.key !== "running" || delayProcess.running) return
     testingDelayGroup = wanted
     lastError = ""
     delayProcess.command = ClashApi.groupDelayCommand(apiBase, config.secret, wanted)
@@ -265,6 +279,7 @@ Item {
     if (!liveConfigs || liveConfigs.tunEnabled === null) return
     pendingTun = liveConfigs.tunEnabled ? 0 : 1
     lastError = ""
+    optimismTimer.restart()
     tunProcess.command = ClashApi.setTunCommand(apiBase, config.secret, pendingTun === 1)
     tunProcess.running = true
   }
@@ -606,6 +621,8 @@ Item {
     onTriggered: {
       root.desiredActive = -1
       root.pendingMode = ""
+      root.pendingNode = null
+      root.pendingTun = -1
     }
   }
 
@@ -631,9 +648,6 @@ Item {
       if (connectionsProcess.running) connectionsProcess.running = false
       if (proxiesProcess.running) proxiesProcess.running = false
       if (subscriptionsReadProcess.running) subscriptionsReadProcess.running = false
-      if (nodeSelectProcess.running) nodeSelectProcess.running = false
-      if (delayProcess.running) delayProcess.running = false
-      if (tunProcess.running) tunProcess.running = false
     }
   }
 
@@ -769,8 +783,14 @@ Item {
       root.liveConfigs = parsed
       // The core has spoken; stop overriding with the click.
       if (root.pendingMode !== "" && parsed.mode === root.pendingMode) root.pendingMode = ""
+      // Same for TUN — including when the core disagrees, but only once the
+      // PATCH has finished: a restart can restore config.yaml's value, and an
+      // authoritative answer that never matches must not hold the toggle busy
+      // forever. While the PATCH is still in flight a disagreeing read is just
+      // the old state, so the overlay stays.
       if (root.pendingTun !== -1 && parsed.tunEnabled !== null
-          && (parsed.tunEnabled === true) === (root.pendingTun === 1)) root.pendingTun = -1
+          && ((parsed.tunEnabled === true) === (root.pendingTun === 1) || !tunProcess.running))
+        root.pendingTun = -1
     }
   }
 
@@ -857,18 +877,24 @@ Item {
     stderr: StdioCollector { id: nodeSelectErr; waitForEnd: true }
     onExited: function(exitCode) {
       var result = ClashApi.classify(exitCode, nodeSelectOut.text, nodeSelectErr.text)
+      var queued = root._queuedNode
+      root._queuedNode = null
       if (!result.ok) {
         root.pendingNode = null
         root.reportError(result.message)
-        return
+      } else {
+        var pending = root.pendingNode
+        if (pending !== null) {
+          root.actionStatus = pending.group + " → " + pending.name
+          actionStatusTimer.restart()
+        }
+        // The overlay stays until /proxies confirms it (or the optimism
+        // deadline drops it): clearing here would snap the picker back to the
+        // stale `now` for the whole round trip, and for good if the refresh
+        // fails after a successful switch.
+        root.refreshProxies()
       }
-      var pending = root.pendingNode
-      if (pending !== null) {
-        root.actionStatus = pending.group + " → " + pending.name
-        actionStatusTimer.restart()
-      }
-      root.pendingNode = null
-      root.refreshProxies()
+      if (queued !== null) root.selectNode(queued.group, queued.name)
     }
   }
 

--- a/Service.qml
+++ b/Service.qml
@@ -188,6 +188,15 @@ Item {
     : (pendingModeProxy !== "" && pendingProxyGroup === currentProxyGroup ? pendingModeProxy
       : (mode === "rule" ? currentRuleProxy : currentGlobalProxy))
 
+  // TUN as the panel should show it: the optimistic overlay while a PATCH is in
+  // flight, the core's own answer otherwise, and null when the core reports no
+  // tun section at all. The menu label, the stat row, and the toggle all read
+  // this, so none of them can disagree about which way the switch is pointing.
+  readonly property var tunState: (liveConfigs && liveConfigs.tunEnabled !== null)
+    ? (pendingTun !== -1 ? pendingTun === 1 : liveConfigs.tunEnabled === true)
+    : null
+  readonly property bool canToggleTun: tunState !== null && connection.key === "running"
+
   readonly property bool busy: probeProcess.running || configReadProcess.running
     || actionProcess.running || modeProcess.running || proxySelectProcess.running
     || configWriteProcess.running || guideProcess.running
@@ -397,12 +406,11 @@ Item {
   // generated config.yaml says. The toggle is offered only when the live core
   // reports a tun field at all.
   function toggleTun() {
-    if (connection.key !== "running" || tunProcess.running) return
-    if (!liveConfigs || liveConfigs.tunEnabled === null) return
+    if (!canToggleTun || tunProcess.running) return
     // Toggle what is on screen, not what the last `/configs` said: the overlay
-    // outlives the PATCH by a round trip, and reading `liveConfigs` there would
+    // outlives the PATCH by a round trip, and reading `liveConfigs` here would
     // make a second press re-send the state the first one already asked for.
-    pendingTun = (pendingTun !== -1 ? pendingTun === 1 : liveConfigs.tunEnabled === true) ? 0 : 1
+    pendingTun = tunState === true ? 0 : 1
     lastError = ""
     optimismTimer.restart()
     tunProcess.command = ClashApi.setTunCommand(apiBase, config.secret, pendingTun === 1)

--- a/Service.qml
+++ b/Service.qml
@@ -75,6 +75,13 @@ Item {
   property var pendingNode: null
   // The TUN state asked for but not yet confirmed by a refresh; -1 means none.
   property int pendingTun: -1
+  // A GET /configs that started before a TUN PATCH finished can exit after it
+  // carrying the old value, and read as the authoritative disagreement that
+  // clears the overlay. The generation counter marks every completed PATCH;
+  // a configs response whose start predates the latest one is re-read instead
+  // of believed.
+  property int _tunPatchCount: 0
+  property int _configsTunGen: 0
   property bool globalSelectionRequested: false
   property string actionKind: ""
   property string actionStatus: ""
@@ -775,6 +782,7 @@ Item {
     command: []
     stdout: StdioCollector { id: configsOut; waitForEnd: true }
     stderr: StdioCollector { id: configsErr; waitForEnd: true }
+    onStarted: root._configsTunGen = root._tunPatchCount
     onExited: function(exitCode) {
       var result = ClashApi.classify(exitCode, configsOut.text, configsErr.text)
       if (!result.ok) return
@@ -783,14 +791,24 @@ Item {
       root.liveConfigs = parsed
       // The core has spoken; stop overriding with the click.
       if (root.pendingMode !== "" && parsed.mode === root.pendingMode) root.pendingMode = ""
-      // Same for TUN — including when the core disagrees, but only once the
-      // PATCH has finished: a restart can restore config.yaml's value, and an
-      // authoritative answer that never matches must not hold the toggle busy
-      // forever. While the PATCH is still in flight a disagreeing read is just
-      // the old state, so the overlay stays.
-      if (root.pendingTun !== -1 && parsed.tunEnabled !== null
-          && ((parsed.tunEnabled === true) === (root.pendingTun === 1) || !tunProcess.running))
+      // Same for TUN — but a disagreeing answer is only authoritative if this
+      // request started after the PATCH finished; one that straddled it is
+      // the old state and is re-read rather than believed. While the PATCH is
+      // still in flight the overlay stays either way: tunProcess.onExited
+      // triggers the confirming refresh.
+      if (root.pendingTun === -1 || parsed.tunEnabled === null) return
+      if ((parsed.tunEnabled === true) === (root.pendingTun === 1)) {
         root.pendingTun = -1
+        return
+      }
+      if (tunProcess.running) return
+      if (root._configsTunGen !== root._tunPatchCount) {
+        configsProcess.running = true
+        return
+      }
+      // A restart can restore config.yaml's value; an authoritative answer
+      // that never matches must not hold the toggle busy forever.
+      root.pendingTun = -1
     }
   }
 
@@ -946,6 +964,10 @@ Item {
       }
       root.actionStatus = root.pendingTun === 1 ? "TUN enabled." : "TUN disabled."
       actionStatusTimer.restart()
+      // Mark the PATCH before refreshing: a /configs already in flight from
+      // before it carries the old value, and the generation is how that
+      // response is told apart from an authoritative disagreement.
+      root._tunPatchCount += 1
       root.refreshApi()
     }
   }

--- a/Service.qml
+++ b/Service.qml
@@ -63,7 +63,7 @@ Item {
   // Selector groups other than GLOBAL (which the mode chips own), each with
   // its nodes and their last measured delay. Filled from the same `/proxies`
   // payload as the global options.
-  property var proxyGroups: []
+  property var selectorGroups: []
   property string testingDelayGroup: ""
   property var ruleProxyOptions: []
   property string currentRuleProxy: ""
@@ -167,6 +167,21 @@ Item {
     : (liveConfigs && liveConfigs.mode !== "" ? liveConfigs.mode : config.mode)
   readonly property string currentProxyGroup: mode === "rule" ? ruleProxyGroup
     : (mode === "global" ? "GLOBAL" : "")
+
+  // The nodes section lists every Selector group the mode row does not already
+  // own. Two pickers over one group would show two answers between a switch
+  // and the next refresh, and their PUTs would race — GLOBAL was excluded at
+  // parse time for exactly that reason, and in rule mode the rule group needs
+  // the same treatment. Derived rather than filtered at parse time so a mode
+  // switch moves the group in or out of the list at once, without waiting for
+  // the next `/proxies`.
+  readonly property var proxyGroups: {
+    var owned = currentProxyGroup
+    var out = []
+    for (var i = 0; i < selectorGroups.length; i++)
+      if (selectorGroups[i].name !== owned) out.push(selectorGroups[i])
+    return out
+  }
   readonly property var currentModeProxyOptions: mode === "rule" ? ruleProxyOptions
     : (mode === "global" ? globalProxyOptions : [])
   readonly property string currentModeProxy: mode === "direct" ? "DIRECT"
@@ -363,7 +378,14 @@ Item {
 
   function testGroupDelay(group) {
     var wanted = String(group || "")
-    if (wanted === "" || connection.key !== "running" || delayProcess.running) return
+    if (wanted === "" || connection.key !== "running") return
+    // The bolt buttons all grey out while a test runs, so only the `d` key can
+    // arrive here mid-test. Saying so beats a keypress that does nothing.
+    if (delayProcess.running) {
+      actionStatus = "Testing " + testingDelayGroup + "…"
+      actionStatusTimer.restart()
+      return
+    }
     testingDelayGroup = wanted
     lastError = ""
     delayProcess.command = ClashApi.groupDelayCommand(apiBase, config.secret, wanted)
@@ -377,7 +399,10 @@ Item {
   function toggleTun() {
     if (connection.key !== "running" || tunProcess.running) return
     if (!liveConfigs || liveConfigs.tunEnabled === null) return
-    pendingTun = liveConfigs.tunEnabled ? 0 : 1
+    // Toggle what is on screen, not what the last `/configs` said: the overlay
+    // outlives the PATCH by a round trip, and reading `liveConfigs` there would
+    // make a second press re-send the state the first one already asked for.
+    pendingTun = (pendingTun !== -1 ? pendingTun === 1 : liveConfigs.tunEnabled === true) ? 0 : 1
     lastError = ""
     optimismTimer.restart()
     tunProcess.command = ClashApi.setTunCommand(apiBase, config.secret, pendingTun === 1)
@@ -1045,7 +1070,7 @@ Item {
       root.routeOptions = ClashApi.parseRouteOptions(result.body)
       var groups = ClashApi.parseSelectorGroups(result.body)
       if (groups) {
-        root.proxyGroups = groups
+        root.selectorGroups = groups
         // The core has spoken; stop overriding with the click.
         if (root.pendingNode !== null) {
           for (var i = 0; i < groups.length; i++) {
@@ -1147,7 +1172,7 @@ Item {
       if (!delays) return
       // Absent from the map means the probe failed, and mihomo records that
       // as delay 0 — write the same value so the two paths agree.
-      var groups = root.proxyGroups.slice()
+      var groups = root.selectorGroups.slice()
       for (var i = 0; i < groups.length; i++) {
         if (groups[i].name !== group) continue
         var nodes = groups[i].nodes.slice()
@@ -1156,7 +1181,7 @@ Item {
         groups[i] = { name: groups[i].name, now: groups[i].now, nodes: nodes }
         break
       }
-      root.proxyGroups = groups
+      root.selectorGroups = groups
       root.actionStatus = "Delays updated."
       actionStatusTimer.restart()
     }

--- a/components/ActionIcon.qml
+++ b/components/ActionIcon.qml
@@ -60,6 +60,12 @@ Canvas {
       move(2.5, 13.5); line(3.4, 10.4); line(11.2, 2.6); line(13.4, 4.8)
       line(5.6, 12.6); ctx.closePath()
       move(9.6, 4.2); line(11.8, 6.4)
+    } else if (root.name === "bolt") {
+      // A lightning bolt for the delay test, pointing down: flat top-right,
+      // notch at the waist, tip at the bottom. Stroked like the rest of the
+      // set, not filled — the weight is what makes it a sibling.
+      move(9.5, 2); line(4.5, 9); line(7.5, 9); line(6.5, 14)
+      line(11.5, 7); line(8.5, 7); ctx.closePath()
     } else if (root.name === "settings") {
       // A gear, built from the grid rather than listed as points: eight teeth
       // are eight identical spokes, and writing them out would only invite one

--- a/components/ConnectionSection.qml
+++ b/components/ConnectionSection.qml
@@ -16,6 +16,9 @@ Column {
   required property var service
   required property color textColor
   required property string panelFontFamily
+  property bool tunCursor: false
+
+  signal tunHovered(bool isHovered)
 
   readonly property bool live: service.apiState === "ok" && service.serviceActive
 
@@ -201,9 +204,15 @@ Column {
           ? root.service.pendingTun === 1
           : (root.service.liveConfigs ? root.service.liveConfigs.tunEnabled === true : false)
         busy: root.service.pendingTun !== -1
+        // A stopped core keeps its last liveConfigs, so the row would stay
+        // live-looking while every click is discarded by toggleTun's guard.
+        interactive: root.live
+        opacity: root.live ? 1.0 : 0.45
         cursorRing: false
+        hasCursor: root.tunCursor
         foreground: root.textColor
         onToggled: root.service.toggleTun()
+        onHovered: function(isHovered) { root.tunHovered(isHovered) }
 
         PanelToolTip {
           visible: tunSwitch.containsMouse

--- a/components/ConnectionSection.qml
+++ b/components/ConnectionSection.qml
@@ -170,6 +170,7 @@ Column {
       spacing: Style.space(6)
 
       SearchableDropdown {
+        id: proxyPicker
         width: parent.width
         label: "Proxy"
         value: root.draftProxy
@@ -180,7 +181,14 @@ Column {
         accent: Color.accent
         fontFamily: root.panelFontFamily
         enabled: !root.applyingProxy
-        onChanged: function(value) { root.draftProxy = value }
+        onChanged: function(value) {
+          root.draftProxy = value
+          // The control writes its own `value` when a row is picked, which
+          // destroys this binding: without putting it back, Cancel would clear
+          // the draft while the picked node stayed in the trigger, and the next
+          // edit would open on it rather than on the current proxy.
+          proxyPicker.value = Qt.binding(function() { return root.draftProxy })
+        }
       }
 
       Row {

--- a/components/ConnectionSection.qml
+++ b/components/ConnectionSection.qml
@@ -16,9 +16,6 @@ Column {
   required property var service
   required property color textColor
   required property string panelFontFamily
-  property bool tunCursor: false
-
-  signal tunHovered(bool isHovered)
 
   readonly property bool live: service.apiState === "ok" && service.serviceActive
   property bool editingProxy: false
@@ -291,58 +288,20 @@ Column {
       value: Model.formatPorts(root.service.config, root.service.liveConfigs)
     }
 
-    // With a tun field the state is switchable, so the row is a toggle; the
-    // read-only "—" remains for cores that report no tun config at all. The
-    // switch patches the running core only — mihoro.toml has no tun key, so a
-    // restart restores whatever config.yaml says, and the tooltip says so.
+    // TUN is a stat here and an action in the panel menu. A switch on this
+    // row put a state change one stray click away inside a block that is
+    // otherwise read-only, and the change is not even persistent: the PATCH
+    // reaches the running core, mihoro.toml has no tun key, and a restart
+    // restores whatever config.yaml says.
     StatRow {
       width: parent.width
-      visible: !root.service.liveConfigs || root.service.liveConfigs.tunEnabled === null
       textColor: root.textColor
       panelFontFamily: root.panelFontFamily
       label: "TUN"
-      value: "—"
-    }
-
-    Item {
-      width: parent.width
-      visible: root.service.liveConfigs && root.service.liveConfigs.tunEnabled !== null
-      implicitHeight: tunSwitch.implicitHeight
-
-      Text {
-        anchors.left: parent.left
-        anchors.verticalCenter: parent.verticalCenter
-        text: "TUN"
-        color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
-        font.family: root.panelFontFamily
-        font.pixelSize: Style.font.caption
-      }
-
-      ToggleSwitch {
-        id: tunSwitch
-        anchors.right: parent.right
-        checked: root.service.pendingTun !== -1
-          ? root.service.pendingTun === 1
-          : (root.service.liveConfigs ? root.service.liveConfigs.tunEnabled === true : false)
-        busy: root.service.pendingTun !== -1
-        // A stopped core keeps its last liveConfigs, so the row would stay
-        // live-looking while every click is discarded by toggleTun's guard.
-        interactive: root.live
-        opacity: root.live ? 1.0 : 0.45
-        // The row is a cursor target, so the switch has to draw the cursor:
-        // `hasCursor` reaches nothing else in ToggleSwitch, and suppressing
-        // the ring left the cursor invisible on this row.
-        hasCursor: root.tunCursor
-        foreground: root.textColor
-        onToggled: root.service.toggleTun()
-        onHovered: function(isHovered) { root.tunHovered(isHovered) }
-
-        PanelToolTip {
-          visible: tunSwitch.containsMouse
-          text: "Runtime only — a restart restores config.yaml"
-          fontFamily: root.panelFontFamily
-        }
-      }
+      value: root.service.tunState === null ? "—"
+        : (root.service.pendingTun !== -1
+          ? (root.service.tunState ? "Enabling…" : "Disabling…")
+          : (root.service.tunState ? "On" : "Off"))
     }
 
     StatRow {

--- a/components/ConnectionSection.qml
+++ b/components/ConnectionSection.qml
@@ -167,19 +167,50 @@ Column {
       value: Model.formatPorts(root.service.config, root.service.liveConfigs)
     }
 
+    // With a tun field the state is switchable, so the row is a toggle; the
+    // read-only "—" remains for cores that report no tun config at all. The
+    // switch patches the running core only — mihoro.toml has no tun key, so a
+    // restart restores whatever config.yaml says, and the tooltip says so.
     StatRow {
       width: parent.width
+      visible: !root.service.liveConfigs || root.service.liveConfigs.tunEnabled === null
       textColor: root.textColor
       panelFontFamily: root.panelFontFamily
       label: "TUN"
-      value: {
-        var liveConfig = root.service.liveConfigs
-        if (!liveConfig || liveConfig.tunEnabled === null) return "—"
-        return liveConfig.tunEnabled ? "enabled" : "disabled"
+      value: "—"
+    }
+
+    Item {
+      width: parent.width
+      visible: root.service.liveConfigs && root.service.liveConfigs.tunEnabled !== null
+      implicitHeight: tunSwitch.implicitHeight
+
+      Text {
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        text: "TUN"
+        color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
       }
-      valueColor: root.service.liveConfigs && root.service.liveConfigs.tunEnabled === true
-        ? Color.accent
-        : root.textColor
+
+      ToggleSwitch {
+        id: tunSwitch
+        anchors.right: parent.right
+        checked: root.service.pendingTun !== -1
+          ? root.service.pendingTun === 1
+          : (root.service.liveConfigs ? root.service.liveConfigs.tunEnabled === true : false)
+        busy: root.service.pendingTun !== -1
+        cursorRing: false
+        foreground: root.textColor
+        onToggled: root.service.toggleTun()
+
+        PanelToolTip {
+          visible: tunSwitch.containsMouse
+          text: "Runtime only — a restart restores config.yaml"
+          fontFamily: root.panelFontFamily
+        }
+      }
     }
 
     StatRow {

--- a/components/ConnectionSection.qml
+++ b/components/ConnectionSection.qml
@@ -329,7 +329,9 @@ Column {
         // live-looking while every click is discarded by toggleTun's guard.
         interactive: root.live
         opacity: root.live ? 1.0 : 0.45
-        cursorRing: false
+        // The row is a cursor target, so the switch has to draw the cursor:
+        // `hasCursor` reaches nothing else in ToggleSwitch, and suppressing
+        // the ring left the cursor invisible on this row.
         hasCursor: root.tunCursor
         foreground: root.textColor
         onToggled: root.service.toggleTun()

--- a/components/ModeSection.qml
+++ b/components/ModeSection.qml
@@ -152,6 +152,7 @@ Column {
   }
 
   SearchableDropdown {
+    id: globalPicker
     width: parent.width
     visible: root.selectingGlobal || root.mode === "global"
     label: "GLOBAL CONNECTION"
@@ -162,7 +163,12 @@ Column {
     foreground: root.textColor
     accent: root.accentColor
     fontFamily: root.panelFontFamily
-    onChanged: function(value) { root.proxyRequested(value) }
+    onChanged: function(value) {
+      root.proxyRequested(value)
+      // Picking writes the control's own `value` and kills this binding, after
+      // which the trigger would keep showing a pick the core never accepted.
+      globalPicker.value = Qt.binding(function() { return root.currentProxy })
+    }
   }
 
   Text {

--- a/components/ModeSection.qml
+++ b/components/ModeSection.qml
@@ -23,12 +23,18 @@ Column {
   property var proxyOptions: []
   property string currentProxy: ""
   property bool selectingGlobal: false
+  // The proxy nodes section hangs off this row: it is a detour most sessions
+  // never take, so it folds into the icon beside the mode chips rather than
+  // standing as a section of its own.
+  property bool nodesAvailable: false
+  property bool nodesExpanded: false
 
   signal modeRequested(string value)
   signal globalRequested()
   signal proxyRequested(string value)
   signal chipHovered(int index, bool isHovered)
   signal subscriptionRequested()
+  signal nodesToggleRequested()
 
   readonly property var options: Model.MODES.map(function(entry) {
     return { value: entry.value, label: entry.label, tooltip: entry.hint }
@@ -70,6 +76,7 @@ Column {
       id: group
       anchors.verticalCenter: parent.verticalCenter
       width: modeControlRow.width - subscriptionButton.width - modeControlRow.spacing
+        - (nodesButton.visible ? nodesButton.width + modeControlRow.spacing : 0)
       spacing: Style.space(6)
       opacity: root.switchable ? 1.0 : 0.45
       enabled: root.switchable
@@ -103,6 +110,24 @@ Column {
             }
           }
         }
+      }
+    }
+
+    PanelActionButton {
+      id: nodesButton
+      anchors.verticalCenter: parent.verticalCenter
+      visible: root.nodesAvailable
+      foreground: root.textColor
+      hoverColor: root.textColor
+      size: Style.space(26)
+      tooltipText: root.nodesExpanded ? "Hide proxy nodes" : "Proxy nodes"
+      onClicked: root.nodesToggleRequested()
+
+      ActionIcon {
+        anchors.centerIn: parent
+        name: root.nodesExpanded ? "arrow-up" : "arrow-down"
+        iconSize: Style.font.body
+        color: nodesButton._hot ? nodesButton.hoverColor : nodesButton.foreground
       }
     }
 

--- a/components/NodesSection.qml
+++ b/components/NodesSection.qml
@@ -1,0 +1,191 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+import "../Model.js" as Model
+
+// Every Selector group the subscription defines (GLOBAL excepted — the mode
+// chips own it), each with a searchable picker over its nodes. This is the
+// panel form of `proxy-node`: pick a group, see each node's last measured
+// delay, switch. Delays come from the core's probe history until the group's
+// test button asks for fresh ones, and the list sorts fastest-first once it
+// has them.
+Column {
+  id: root
+
+  required property color textColor
+  required property string panelFontFamily
+  required property color fastColor
+  required property color slowColor
+  property color accentColor: Color.accent
+  property var groups: []
+  // The switch in flight, as `{group, name}`; null when nothing is.
+  property var pendingNode: null
+  property string testingGroup: ""
+  property int cursorIndex: -1
+
+  signal nodeRequested(string group, string name)
+  signal testRequested(string group)
+  signal dropdownHovered(int index, bool isHovered)
+
+  // While any group's picker is open its search field owns the keys; the
+  // panel reads this to suspend its own shortcuts, as it does for the URL
+  // editor.
+  readonly property bool searchOpen: {
+    for (var i = 0; i < groupRepeater.count; i++) {
+      var item = groupRepeater.itemAt(i)
+      if (item && item.dropdownOpen) return true
+    }
+    return false
+  }
+
+  function openGroup(name) {
+    for (var i = 0; i < groupRepeater.count; i++) {
+      var item = groupRepeater.itemAt(i)
+      if (item && item.groupName === String(name)) { item.openDropdown(); return }
+    }
+  }
+
+  function delayFor(group, nodeName) {
+    var nodes = group.nodes
+    for (var i = 0; i < nodes.length; i++)
+      if (nodes[i].name === nodeName) return nodes[i].delay
+    return NaN
+  }
+
+  function delayColor(ms) {
+    var state = Model.delayState(ms)
+    if (state === "fast") return root.fastColor
+    if (state === "slow") return root.slowColor
+    return Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
+  }
+
+  spacing: Style.space(8)
+
+  Item {
+    width: parent.width
+    implicitHeight: Math.max(nodesHeader.implicitHeight, testingLabel.implicitHeight)
+
+    PanelSectionHeader {
+      id: nodesHeader
+      anchors.left: parent.left
+      anchors.verticalCenter: parent.verticalCenter
+      text: "PROXY NODES"
+      foreground: root.textColor
+      fontFamily: root.panelFontFamily
+    }
+
+    Text {
+      id: testingLabel
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      visible: root.testingGroup !== ""
+      text: "testing…"
+      color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+    }
+  }
+
+  Repeater {
+    id: groupRepeater
+    model: root.groups
+
+    delegate: Column {
+      id: groupRow
+      required property var modelData
+      required property int index
+
+      readonly property string groupName: String(modelData.name)
+      readonly property string currentNode: root.pendingNode !== null && root.pendingNode.group === groupName
+        ? String(root.pendingNode.name)
+        : String(modelData.now)
+      readonly property real currentDelay: root.delayFor(modelData, currentNode)
+      readonly property alias dropdownOpen: dropdown.popupOpen
+
+      function openDropdown() { dropdown.open() }
+
+      width: parent.width
+      spacing: Style.space(6)
+
+      Item {
+        width: parent.width
+        implicitHeight: Math.max(groupLabel.implicitHeight, testButton.implicitHeight)
+
+        Text {
+          id: groupLabel
+          anchors.left: parent.left
+          anchors.right: testButton.left
+          anchors.rightMargin: Style.space(6)
+          anchors.verticalCenter: parent.verticalCenter
+          text: groupRow.groupName
+          color: root.textColor
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.bodySmall
+          font.bold: true
+          elide: Text.ElideRight
+        }
+
+        PanelActionButton {
+          id: testButton
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+          foreground: root.textColor
+          hoverColor: root.textColor
+          size: Style.space(26)
+          enabled: root.testingGroup === ""
+          opacity: enabled ? 1.0 : 0.45
+          tooltipText: "Test delays"
+          onClicked: root.testRequested(groupRow.groupName)
+
+          ActionIcon {
+            anchors.centerIn: parent
+            name: "bolt"
+            iconSize: Style.font.body
+            color: testButton._hot ? testButton.hoverColor : testButton.foreground
+          }
+        }
+      }
+
+      Row {
+        width: parent.width
+        spacing: Style.space(6)
+        visible: groupRow.currentNode !== ""
+
+        Text {
+          text: "now: " + groupRow.currentNode
+          color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideRight
+          width: Math.min(implicitWidth, parent.width - delayText.width - parent.spacing)
+        }
+
+        Text {
+          id: delayText
+          text: Model.formatDelay(groupRow.currentDelay)
+          color: root.delayColor(groupRow.currentDelay)
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.caption
+        }
+      }
+
+      SearchableDropdown {
+        id: dropdown
+        width: parent.width
+        showLabel: false
+        value: groupRow.currentNode
+        options: Model.sortNodesByDelay(groupRow.modelData.nodes).map(function(node) {
+          return { value: node.name, label: node.name, description: Model.formatDelay(node.delay) }
+        })
+        placeholderText: "Choose a node…"
+        emptyText: "No nodes available"
+        foreground: root.textColor
+        accent: root.accentColor
+        fontFamily: root.panelFontFamily
+        hasCursor: root.cursorIndex === groupRow.index
+        onChanged: function(value) { root.nodeRequested(groupRow.groupName, value) }
+        onHovered: function(isHovered) { root.dropdownHovered(groupRow.index, isHovered) }
+      }
+    }
+  }
+}

--- a/components/NodesSection.qml
+++ b/components/NodesSection.qml
@@ -21,6 +21,11 @@ Column {
   // The switch in flight, as `{group, name}`; null when nothing is.
   property var pendingNode: null
   property string testingGroup: ""
+  // Not `enabled`: that is an Item property, and shadowing it would also stop
+  // the section receiving input events rather than just greying out. False
+  // when the API is not answering — a picker against a dead core would fire a
+  // doomed PUT and the data on screen is stale anyway.
+  property bool switchable: true
   property int cursorIndex: -1
 
   signal nodeRequested(string group, string name)
@@ -132,7 +137,7 @@ Column {
           foreground: root.textColor
           hoverColor: root.textColor
           size: Style.space(26)
-          enabled: root.testingGroup === ""
+          enabled: root.switchable && root.testingGroup === ""
           opacity: enabled ? 1.0 : 0.45
           tooltipText: "Test delays"
           onClicked: root.testRequested(groupRow.groupName)
@@ -173,6 +178,8 @@ Column {
         id: dropdown
         width: parent.width
         showLabel: false
+        enabled: root.switchable
+        opacity: root.switchable ? 1.0 : 0.45
         value: groupRow.currentNode
         options: Model.sortNodesByDelay(groupRow.modelData.nodes).map(function(node) {
           return { value: node.name, label: node.name, description: Model.formatDelay(node.delay) }

--- a/components/NodesSection.qml
+++ b/components/NodesSection.qml
@@ -167,6 +167,9 @@ Column {
         // clearing it here is what takes the buttons away again.
         property string draftNode: ""
         readonly property bool hasDraft: draftNode !== "" && draftNode !== currentNode
+        // What the picker should be showing: the draft while there is one, the
+        // core's own answer otherwise.
+        readonly property string pickerValue: draftNode !== "" ? draftNode : currentNode
 
         function openDropdown() { dropdown.open() }
         function closeDropdown() { dropdown.close() }
@@ -254,7 +257,7 @@ Column {
           showLabel: false
           enabled: root.switchable
           opacity: root.switchable ? 1.0 : 0.45
-          value: groupRow.draftNode !== "" ? groupRow.draftNode : groupRow.currentNode
+          value: groupRow.pickerValue
           options: Model.sortNodesByDelay(groupRow.group.nodes).map(function(node) {
             return { value: node.name, label: node.name, description: Model.formatDelay(node.delay) }
           })
@@ -264,7 +267,15 @@ Column {
           accent: root.accentColor
           fontFamily: root.panelFontFamily
           hasCursor: root.cursorIndex === groupRow.index
-          onChanged: function(value) { groupRow.draftNode = String(value) }
+          onChanged: function(value) {
+            groupRow.draftNode = String(value)
+            // SearchableDropdown assigns its own `value` when a row is picked,
+            // and that assignment destroys the binding installed above: after
+            // one pick the trigger stopped following anything, so Cancel
+            // cleared the draft while the picked node stayed on screen. Put the
+            // binding back each time the control breaks it.
+            dropdown.value = Qt.binding(function() { return groupRow.pickerValue })
+          }
           onHovered: function(isHovered) { root.dropdownHovered(groupRow.index, isHovered) }
         }
 

--- a/components/NodesSection.qml
+++ b/components/NodesSection.qml
@@ -3,12 +3,20 @@ import qs.Commons
 import qs.Ui
 import "../Model.js" as Model
 
-// Every Selector group the subscription defines (GLOBAL excepted — the mode
-// chips own it), each with a searchable picker over its nodes. This is the
-// panel form of `proxy-node`: pick a group, see each node's last measured
-// delay, switch. Delays come from the core's probe history until the group's
-// test button asks for fresh ones, and the list sorts fastest-first once it
-// has them.
+// Every Selector group the mode row does not already own, each with a
+// searchable picker over its nodes. This is the panel form of `proxy-node`:
+// pick a group, see each node's last measured delay, switch. Delays come from
+// the core's probe history until the group's test button asks for fresh ones,
+// and the list sorts fastest-first once it has them.
+//
+// Collapsed by default. A subscription with a handful of groups is three lines
+// each, which would push CONNECTION off the bottom of the panel for everyone,
+// including the majority who never change a node. The header is the disclosure
+// and the section's single cursor target while it is shut.
+//
+// A pick is a draft until Apply, as it is for the mode row's proxy — switching
+// on selection would fire a PUT at whatever the search filter happened to land
+// on while typing.
 Column {
   id: root
 
@@ -27,15 +35,22 @@ Column {
   // doomed PUT and the data on screen is stale anyway.
   property bool switchable: true
   property int cursorIndex: -1
+  property bool headerCursor: false
+  // Owned by the panel, which needs it to build the cursor target list before
+  // this section exists.
+  property bool expanded: false
 
   signal nodeRequested(string group, string name)
   signal testRequested(string group)
+  signal toggleRequested()
   signal dropdownHovered(int index, bool isHovered)
+  signal headerHovered(bool isHovered)
 
   // While any group's picker is open its search field owns the keys; the
   // panel reads this to suspend its own shortcuts, as it does for the URL
   // editor.
   readonly property bool searchOpen: {
+    if (!expanded) return false
     for (var i = 0; i < groupRepeater.count; i++) {
       var item = groupRepeater.itemAt(i)
       if (item && item.dropdownOpen) return true
@@ -43,11 +58,44 @@ Column {
     return false
   }
 
-  function openGroup(name) {
+  // The Repeater is keyed on group names rather than the group objects: a
+  // delegate model over a JS array is rebuilt whenever the array's contents
+  // change, and the groups carry the delays, so every refresh that measured
+  // something new — a delay test above all — would destroy the open picker and
+  // any unapplied draft with it. The names change only when the subscription
+  // does, and each delegate reads its own group through `groupFor`, whose
+  // bindings update in place.
+  readonly property var groupNames: {
+    var out = []
+    for (var i = 0; i < groups.length; i++) out.push(String(groups[i].name))
+    return out
+  }
+
+  function groupFor(name) {
+    var wanted = String(name)
+    for (var i = 0; i < groups.length; i++)
+      if (String(groups[i].name) === wanted) return groups[i]
+    return { name: wanted, now: "", nodes: [] }
+  }
+
+  function itemFor(name) {
     for (var i = 0; i < groupRepeater.count; i++) {
       var item = groupRepeater.itemAt(i)
-      if (item && item.groupName === String(name)) { item.openDropdown(); return }
+      if (item && item.groupName === String(name)) return item
     }
+    return null
+  }
+
+  function openGroup(name) {
+    var item = itemFor(name)
+    if (item) item.openDropdown()
+  }
+
+  // Enter on a group row: confirm the drafted pick if there is one, otherwise
+  // open the picker. One key walks the whole switch.
+  function activateGroup(name) {
+    var item = itemFor(name)
+    if (item) item.activate()
   }
 
   function delayFor(group, nodeName) {
@@ -66,13 +114,26 @@ Column {
 
   spacing: Style.space(8)
 
-  Item {
+  CursorSurface {
+    id: header
     width: parent.width
-    implicitHeight: Math.max(nodesHeader.implicitHeight, testingLabel.implicitHeight)
+    implicitHeight: Math.max(nodesHeader.implicitHeight, chevron.height) + Style.space(10)
+    foreground: root.textColor
+    accent: root.accentColor
+    hasCursor: root.headerCursor
+
+    MouseArea {
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onContainsMouseChanged: root.headerHovered(containsMouse)
+      onClicked: root.toggleRequested()
+    }
 
     PanelSectionHeader {
       id: nodesHeader
       anchors.left: parent.left
+      anchors.leftMargin: Style.space(6)
       anchors.verticalCenter: parent.verticalCenter
       text: "PROXY NODES"
       foreground: root.textColor
@@ -80,118 +141,187 @@ Column {
     }
 
     Text {
-      id: testingLabel
-      anchors.right: parent.right
+      id: headerNote
+      anchors.right: chevron.left
+      anchors.rightMargin: Style.space(6)
       anchors.verticalCenter: parent.verticalCenter
-      visible: root.testingGroup !== ""
-      text: "testing…"
+      // The count is what the section is worth opening for while it is shut;
+      // a running test outranks it, since that is the one thing in here that
+      // finishes on its own.
+      text: root.testingGroup !== "" ? "testing…"
+        : (root.expanded ? "" : root.groups.length + (root.groups.length === 1 ? " group" : " groups"))
       color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.caption
     }
+
+    ActionIcon {
+      id: chevron
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(6)
+      anchors.verticalCenter: parent.verticalCenter
+      name: root.expanded ? "arrow-up" : "arrow-down"
+      iconSize: Style.font.icon
+      color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
+    }
   }
 
-  Repeater {
-    id: groupRepeater
-    model: root.groups
+  Column {
+    id: groupList
+    width: parent.width
+    spacing: Style.space(8)
+    visible: root.expanded
 
-    delegate: Column {
-      id: groupRow
-      required property var modelData
-      required property int index
+    Repeater {
+      id: groupRepeater
+      // Empty while the section is shut, so nothing is built for rows nobody
+      // can reach: a shut section takes its open pickers and unapplied drafts
+      // with it, rather than hiding a switch that is still waiting to fire.
+      model: root.expanded ? root.groupNames : []
 
-      readonly property string groupName: String(modelData.name)
-      readonly property string currentNode: root.pendingNode !== null && root.pendingNode.group === groupName
-        ? String(root.pendingNode.name)
-        : String(modelData.now)
-      readonly property real currentDelay: root.delayFor(modelData, currentNode)
-      readonly property alias dropdownOpen: dropdown.popupOpen
+      delegate: Column {
+        id: groupRow
+        required property var modelData
+        required property int index
 
-      function openDropdown() { dropdown.open() }
+        readonly property string groupName: String(modelData)
+        readonly property var group: root.groupFor(groupRow.groupName)
+        readonly property string currentNode: root.pendingNode !== null && root.pendingNode.group === groupName
+          ? String(root.pendingNode.name)
+          : String(group.now)
+        readonly property real currentDelay: root.delayFor(groupRow.group, currentNode)
+        readonly property alias dropdownOpen: dropdown.popupOpen
+        // The pick waiting for Apply. Empty means the row shows the core's
+        // own answer; the optimistic overlay makes an applied pick current, so
+        // clearing it here is what takes the buttons away again.
+        property string draftNode: ""
+        readonly property bool hasDraft: draftNode !== "" && draftNode !== currentNode
 
-      width: parent.width
-      spacing: Style.space(6)
+        function openDropdown() { dropdown.open() }
+        function closeDropdown() { dropdown.close() }
+        function cancel() { draftNode = "" }
 
-      Item {
-        width: parent.width
-        implicitHeight: Math.max(groupLabel.implicitHeight, testButton.implicitHeight)
-
-        Text {
-          id: groupLabel
-          anchors.left: parent.left
-          anchors.right: testButton.left
-          anchors.rightMargin: Style.space(6)
-          anchors.verticalCenter: parent.verticalCenter
-          text: groupRow.groupName
-          color: root.textColor
-          font.family: root.panelFontFamily
-          font.pixelSize: Style.font.bodySmall
-          font.bold: true
-          elide: Text.ElideRight
+        function apply() {
+          if (!root.switchable || !hasDraft) return
+          root.nodeRequested(groupName, draftNode)
+          draftNode = ""
         }
 
-        PanelActionButton {
-          id: testButton
-          anchors.right: parent.right
-          anchors.verticalCenter: parent.verticalCenter
-          foreground: root.textColor
-          hoverColor: root.textColor
-          size: Style.space(26)
-          enabled: root.switchable && root.testingGroup === ""
-          opacity: enabled ? 1.0 : 0.45
-          tooltipText: "Test delays"
-          onClicked: root.testRequested(groupRow.groupName)
-
-          ActionIcon {
-            anchors.centerIn: parent
-            name: "bolt"
-            iconSize: Style.font.body
-            color: testButton._hot ? testButton.hoverColor : testButton.foreground
-          }
+        function activate() {
+          if (hasDraft) apply()
+          else if (root.switchable) dropdown.open()
         }
-      }
 
-      Row {
         width: parent.width
         spacing: Style.space(6)
-        visible: groupRow.currentNode !== ""
 
-        Text {
-          text: "now: " + groupRow.currentNode
-          color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
-          font.family: root.panelFontFamily
-          font.pixelSize: Style.font.caption
-          elide: Text.ElideRight
-          width: Math.min(implicitWidth, parent.width - delayText.width - parent.spacing)
+        Item {
+          width: parent.width
+          implicitHeight: Math.max(groupLabel.implicitHeight, testButton.implicitHeight)
+
+          Text {
+            id: groupLabel
+            anchors.left: parent.left
+            anchors.right: testButton.left
+            anchors.rightMargin: Style.space(6)
+            anchors.verticalCenter: parent.verticalCenter
+            text: groupRow.groupName
+            color: root.textColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.bodySmall
+            font.bold: true
+            elide: Text.ElideRight
+          }
+
+          PanelActionButton {
+            id: testButton
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            foreground: root.textColor
+            hoverColor: root.textColor
+            size: Style.space(26)
+            enabled: root.switchable && root.testingGroup === ""
+            opacity: enabled ? 1.0 : 0.45
+            tooltipText: "Test delays"
+            onClicked: root.testRequested(groupRow.groupName)
+
+            ActionIcon {
+              anchors.centerIn: parent
+              name: "bolt"
+              iconSize: Style.font.body
+              color: testButton._hot ? testButton.hoverColor : testButton.foreground
+            }
+          }
         }
 
-        Text {
-          id: delayText
-          text: Model.formatDelay(groupRow.currentDelay)
-          color: root.delayColor(groupRow.currentDelay)
-          font.family: root.panelFontFamily
-          font.pixelSize: Style.font.caption
-        }
-      }
+        Row {
+          width: parent.width
+          spacing: Style.space(6)
+          visible: groupRow.currentNode !== ""
 
-      SearchableDropdown {
-        id: dropdown
-        width: parent.width
-        showLabel: false
-        enabled: root.switchable
-        opacity: root.switchable ? 1.0 : 0.45
-        value: groupRow.currentNode
-        options: Model.sortNodesByDelay(groupRow.modelData.nodes).map(function(node) {
-          return { value: node.name, label: node.name, description: Model.formatDelay(node.delay) }
-        })
-        placeholderText: "Choose a node…"
-        emptyText: "No nodes available"
-        foreground: root.textColor
-        accent: root.accentColor
-        fontFamily: root.panelFontFamily
-        hasCursor: root.cursorIndex === groupRow.index
-        onChanged: function(value) { root.nodeRequested(groupRow.groupName, value) }
-        onHovered: function(isHovered) { root.dropdownHovered(groupRow.index, isHovered) }
+          Text {
+            text: "now: " + groupRow.currentNode
+            color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.caption
+            elide: Text.ElideRight
+            width: Math.min(implicitWidth, parent.width - delayText.width - parent.spacing)
+          }
+
+          Text {
+            id: delayText
+            text: Model.formatDelay(groupRow.currentDelay)
+            color: root.delayColor(groupRow.currentDelay)
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.caption
+          }
+        }
+
+        SearchableDropdown {
+          id: dropdown
+          width: parent.width
+          showLabel: false
+          enabled: root.switchable
+          opacity: root.switchable ? 1.0 : 0.45
+          value: groupRow.draftNode !== "" ? groupRow.draftNode : groupRow.currentNode
+          options: Model.sortNodesByDelay(groupRow.group.nodes).map(function(node) {
+            return { value: node.name, label: node.name, description: Model.formatDelay(node.delay) }
+          })
+          placeholderText: "Choose a node…"
+          emptyText: "No nodes available"
+          foreground: root.textColor
+          accent: root.accentColor
+          fontFamily: root.panelFontFamily
+          hasCursor: root.cursorIndex === groupRow.index
+          onChanged: function(value) { groupRow.draftNode = String(value) }
+          onHovered: function(isHovered) { root.dropdownHovered(groupRow.index, isHovered) }
+        }
+
+        Row {
+          id: groupActions
+          width: parent.width
+          spacing: Style.spacing.controlGap
+          visible: groupRow.hasDraft
+
+          Button {
+            width: (groupActions.width - groupActions.spacing) / 2
+            text: "Apply"
+            foreground: root.textColor
+            bordered: true
+            fontSize: Style.font.bodySmall
+            enabled: root.switchable
+            onClicked: groupRow.apply()
+          }
+
+          Button {
+            width: (groupActions.width - groupActions.spacing) / 2
+            text: "Cancel"
+            foreground: root.textColor
+            bordered: true
+            fontSize: Style.font.bodySmall
+            onClicked: groupRow.cancel()
+          }
+        }
       }
     }
   }

--- a/components/NodesSection.qml
+++ b/components/NodesSection.qml
@@ -9,10 +9,11 @@ import "../Model.js" as Model
 // the core's probe history until the group's test button asks for fresh ones,
 // and the list sorts fastest-first once it has them.
 //
-// Collapsed by default. A subscription with a handful of groups is three lines
-// each, which would push CONNECTION off the bottom of the panel for everyone,
-// including the majority who never change a node. The header is the disclosure
-// and the section's single cursor target while it is shut.
+// Folded away by default. A subscription with a handful of groups is three
+// lines each, which would push CONNECTION off the bottom of the panel for
+// everyone, including the majority who never change a node. The disclosure is
+// the icon on the mode row, so nothing of this section is on screen — not even
+// a header — until it is asked for.
 //
 // A pick is a draft until Apply, as it is for the mode row's proxy — switching
 // on selection would fire a PUT at whatever the search filter happened to land
@@ -35,16 +36,13 @@ Column {
   // doomed PUT and the data on screen is stale anyway.
   property bool switchable: true
   property int cursorIndex: -1
-  property bool headerCursor: false
   // Owned by the panel, which needs it to build the cursor target list before
-  // this section exists.
+  // this section exists, and which puts the disclosure on the mode row.
   property bool expanded: false
 
   signal nodeRequested(string group, string name)
   signal testRequested(string group)
-  signal toggleRequested()
   signal dropdownHovered(int index, bool isHovered)
-  signal headerHovered(bool isHovered)
 
   // While any group's picker is open its search field owns the keys; the
   // panel reads this to suspend its own shortcuts, as it does for the URL
@@ -114,63 +112,36 @@ Column {
 
   spacing: Style.space(8)
 
-  CursorSurface {
-    id: header
-    width: parent.width
-    implicitHeight: Math.max(nodesHeader.implicitHeight, chevron.height) + Style.space(10)
-    foreground: root.textColor
-    accent: root.accentColor
-    hasCursor: root.headerCursor
-
-    MouseArea {
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: Qt.PointingHandCursor
-      onContainsMouseChanged: root.headerHovered(containsMouse)
-      onClicked: root.toggleRequested()
-    }
-
-    PanelSectionHeader {
-      id: nodesHeader
-      anchors.left: parent.left
-      anchors.leftMargin: Style.space(6)
-      anchors.verticalCenter: parent.verticalCenter
-      text: "PROXY NODES"
-      foreground: root.textColor
-      fontFamily: root.panelFontFamily
-    }
-
-    Text {
-      id: headerNote
-      anchors.right: chevron.left
-      anchors.rightMargin: Style.space(6)
-      anchors.verticalCenter: parent.verticalCenter
-      // The count is what the section is worth opening for while it is shut;
-      // a running test outranks it, since that is the one thing in here that
-      // finishes on its own.
-      text: root.testingGroup !== "" ? "testing…"
-        : (root.expanded ? "" : root.groups.length + (root.groups.length === 1 ? " group" : " groups"))
-      color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
-      font.family: root.panelFontFamily
-      font.pixelSize: Style.font.caption
-    }
-
-    ActionIcon {
-      id: chevron
-      anchors.right: parent.right
-      anchors.rightMargin: Style.space(6)
-      anchors.verticalCenter: parent.verticalCenter
-      name: root.expanded ? "arrow-up" : "arrow-down"
-      iconSize: Style.font.icon
-      color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
-    }
-  }
-
   Column {
     id: groupList
     width: parent.width
     spacing: Style.space(8)
     visible: root.expanded
+
+    Item {
+      width: parent.width
+      implicitHeight: Math.max(nodesHeader.implicitHeight, testingLabel.implicitHeight)
+
+      PanelSectionHeader {
+        id: nodesHeader
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        text: "PROXY NODES"
+        foreground: root.textColor
+        fontFamily: root.panelFontFamily
+      }
+
+      Text {
+        id: testingLabel
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        visible: root.testingGroup !== ""
+        text: "testing…"
+        color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.55)
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+      }
+    }
 
     Repeater {
       id: groupRepeater

--- a/components/PanelMenu.qml
+++ b/components/PanelMenu.qml
@@ -129,7 +129,6 @@ Item {
         onActivated: root.openUrl("https://github.com/huacnlee/omarchy-mihoro")
       }
       MenuRow { text: "Mihoro..."; onActivated: root.openUrl(Model.PROJECT_URL) }
-      MenuRow { text: "Mihoro docs..."; onActivated: root.openUrl(Model.INSTALL_DOCS_URL) }
 
       Item {
         width: menu.width - menu.leftPadding - menu.rightPadding

--- a/components/PanelMenu.qml
+++ b/components/PanelMenu.qml
@@ -19,8 +19,11 @@ Item {
   property bool canCopyProxy: false
   property bool canOpenRules: false
   property bool canTestRoutes: false
+  property bool canToggleTun: false
+  property bool tunEnabled: false
 
   signal restartRequested()
+  signal tunRequested()
   signal copyProxyRequested()
   signal installRequested()
   signal subscriptionRequested()
@@ -135,6 +138,18 @@ Item {
           anchors.verticalCenter: parent.verticalCenter
           width: parent.width
           foreground: root.textColor
+        }
+      }
+
+      MenuRow {
+        // The verb, not the state: a row that read "TUN" would leave the user
+        // to guess which way activating it points. Runtime only — a restart
+        // brings back whatever config.yaml says.
+        text: root.tunEnabled ? "Disable TUN" : "Enable TUN"
+        enabled: root.canToggleTun
+        onActivated: {
+          menu.close()
+          root.tunRequested()
         }
       }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "id": "mihoro.omarchy",
   "name": "Mihoro",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Jason Lee <huacnlee@gmail.com>",
   "license": "MIT",
-  "description": "A Clash-style proxy client for Omarchy, running the Mihomo (Clash.Meta) core: connection status, live up/down speed, Rule, Global and Direct switching, and several Clash subscriptions to switch between, driven by the mihoro CLI.",
+  "description": "A Clash-style proxy client for Omarchy, running the Mihomo (Clash.Meta) core: connection status, live up/down speed, Rule, Global and Direct switching, proxy-node selection with delay tests, TUN toggling, and several Clash subscriptions to switch between, driven by the mihoro CLI.",
   "kinds": [
     "bar-widget"
   ],
@@ -15,7 +15,7 @@
   },
   "barWidget": {
     "displayName": "Mihoro",
-    "description": "A Clash-style proxy client in the bar: watch the Mihomo core, switch between Rule, Global and Direct, and keep several subscriptions to switch between.",
+    "description": "A Clash-style proxy client in the bar: watch the Mihomo core, switch between Rule, Global and Direct, pick proxy nodes by measured delay, toggle TUN, and keep several subscriptions to switch between.",
     "category": "Network",
     "aliases": [
       "mihomo",

--- a/probe-arrayisarray.qml
+++ b/probe-arrayisarray.qml
@@ -1,0 +1,33 @@
+import QtQuick
+import Quickshell
+import "Model.js" as Model
+
+// Probe: does a nested array survive the Instantiator/Repeater modelData
+// boundary as a real JS Array? Reproduces the panel path
+// Service.proxyGroups → Repeater → modelData.nodes → Model.sortNodesByDelay.
+ShellRoot {
+  Scope {
+    id: probeRoot
+    property var groups: [
+      { name: "AI", now: "a", nodes: [ { name: "a", delay: 212 }, { name: "b", delay: 39 } ] }
+    ]
+
+    Instantiator {
+      model: probeRoot.groups
+      Scope {
+        id: row
+        required property var modelData
+        Component.onCompleted: {
+          var nodes = row.modelData.nodes
+          console.log("typeof nodes:", typeof nodes)
+          console.log("Array.isArray:", Array.isArray(nodes))
+          console.log("instanceof Array:", nodes instanceof Array)
+          console.log("length:", nodes && nodes.length, "nodes[0].delay:", nodes && nodes[0] ? nodes[0].delay : "?")
+          var sorted = Model.sortNodesByDelay(nodes)
+          console.log("sortNodesByDelay length:", sorted.length)
+          Qt.quit()
+        }
+      }
+    }
+  }
+}

--- a/tests/probe-arrayisarray.qml
+++ b/tests/probe-arrayisarray.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import Quickshell
-import "Model.js" as Model
+import "../Model.js" as Model
 
 // Probe: does a nested array survive the Instantiator/Repeater modelData
 // boundary as a real JS Array? Reproduces the panel path

--- a/tests/test_clash_api.js
+++ b/tests/test_clash_api.js
@@ -194,6 +194,23 @@ assert.deepStrictEqual(Array.from(ruleProxy.options, option => option.value), ["
 assert.strictEqual(api.parseProxyGroup('{"proxies":{}}', "PROXY").options.length, 0)
 assert.strictEqual(api.parseProxyGroup("nope", "PROXY"), null)
 
+// The group name comes from the subscription, and not every one calls it
+// `PROXY` — some ship `Proxy`. Lookups resolve the payload's real key
+// case-insensitively, because both this parse and the PUT path must address
+// the group the core actually has.
+const lowerProxy = api.parseProxyGroup(JSON.stringify({
+  proxies: {
+    GLOBAL: { type: "Selector", now: "Singapore", all: ["Singapore"] },
+    Proxy: { type: "Selector", now: "Tokyo JP", all: ["DIRECT", "Tokyo JP"] }
+  }
+}), "PROXY")
+assert.strictEqual(lowerProxy.current, "Tokyo JP")
+assert.deepStrictEqual(Array.from(lowerProxy.options, option => option.value), ["DIRECT", "Tokyo JP"])
+assert.strictEqual(api.resolveGroupName(JSON.stringify({ proxies: { Proxy: { type: "Selector" } } }), "PROXY"), "Proxy")
+assert.strictEqual(api.resolveGroupName(JSON.stringify({ proxies: { PROXY: { type: "Selector" } } }), "PROXY"), "PROXY")
+assert.strictEqual(api.resolveGroupName(JSON.stringify({ proxies: {} }), "PROXY"), null)
+assert.strictEqual(api.resolveGroupName("nope", "PROXY"), null)
+
 const routes = api.parseRouteOptions(JSON.stringify({ proxies: {
   DIRECT: { type: "Direct" },
   REJECT: { type: "Reject" },

--- a/tests/test_clash_api.js
+++ b/tests/test_clash_api.js
@@ -228,4 +228,53 @@ assert.strictEqual(legacy.anchor, null)
 
 assert.strictEqual(api.trafficRate(null, null, 1), null)
 
+// --------------------------------------------------------- selector groups
+//
+// What `proxy-node` reads from the same payload: every Selector group except
+// GLOBAL, each node carrying the last delay the core measured for it.
+
+const proxiesBody = JSON.stringify({
+  proxies: {
+    GLOBAL: { type: "Selector", now: "B", all: ["A", "B"] },
+    "Proxy": {
+      type: "Selector",
+      now: "A",
+      all: ["A", "B", "C"]
+    },
+    "Auto": { type: "URLTest", now: "A", all: ["A", "B"] },
+    "A": { type: "Shadowsocks", history: [{ time: "t1", delay: 120 }, { time: "t2", delay: 96 }] },
+    "B": { type: "Vmess", history: [] },
+    "C": { type: "Trojan", history: [{ time: "t3", delay: 0 }] }
+  }
+})
+
+const groups = api.parseSelectorGroups(proxiesBody)
+assert.strictEqual(groups.length, 1, "only non-GLOBAL Selector groups")
+assert.strictEqual(groups[0].name, "Proxy")
+assert.strictEqual(groups[0].now, "A")
+assert.strictEqual(groups[0].nodes.length, 3)
+assert.strictEqual(groups[0].nodes[0].name, "A")
+assert.strictEqual(groups[0].nodes[0].delay, 96, "the last history entry, not the first")
+assert.ok(Number.isNaN(groups[0].nodes[1].delay), "no history stays NaN, not 0")
+assert.strictEqual(groups[0].nodes[2].delay, 0, "a failed probe is delay 0")
+assert.strictEqual(api.parseSelectorGroups("{}"), null)
+assert.strictEqual(api.parseSelectorGroups("not json"), null)
+
+const groupDelay = api.parseGroupDelay('{"A": 96, "B": 1024}')
+assert.strictEqual(groupDelay.A, 96)
+assert.strictEqual(groupDelay.B, 1024)
+assert.strictEqual(groupDelay.C, undefined, "absent means the probe failed")
+assert.strictEqual(api.parseGroupDelay("not json"), null)
+
+const delayCmd = api.groupDelayCommand("http://127.0.0.1:9090", "s3cret", "My Group")
+assert.strictEqual(delayCmd[delayCmd.length - 1],
+  "http://127.0.0.1:9090/group/My%20Group/delay?url=http%3A%2F%2Fwww.gstatic.com%2Fgenerate_204&timeout=5000")
+assert.ok(delayCmd.some(arg => /Authorization: Bearer s3cret/.test(arg)))
+
+const tunOn = api.setTunCommand("http://127.0.0.1:9090", "", true)
+assert.strictEqual(tunOn[tunOn.length - 1], "http://127.0.0.1:9090/configs")
+assert.ok(tunOn.includes("PATCH"))
+assert.ok(tunOn.some(arg => arg === '{"tun":{"enable":true}}'))
+assert.ok(api.setTunCommand("http://127.0.0.1:9090", "", false).some(arg => arg === '{"tun":{"enable":false}}'))
+
 console.log("clash API tests passed")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -545,4 +545,18 @@ assert.strictEqual(model.sortNodesByDelay(null).length, 0)
 const tied = model.sortNodesByDelay([{ name: "x", delay: 100 }, { name: "y", delay: 100 }])
 assert.strictEqual(tied.map(node => node.name).join(","), "x,y")
 
+// An array handed through a QML delegate boundary (Repeater/Instantiator
+// modelData) arrives as a sequence wrapper: `length` and indexing work and
+// `instanceof Array` is even true, but `Array.isArray` is false. The sort has
+// to accept it — this exact shape emptied every node picker in the panel
+// (probe-arrayisarray.qml reproduces the wrapper in a real QML engine).
+const qmlSequence = Object.create(Array.prototype)
+qmlSequence[0] = { name: "wrapped-slow", delay: 212 }
+qmlSequence[1] = { name: "wrapped-fast", delay: 39 }
+qmlSequence.length = 2
+assert.strictEqual(Array.isArray(qmlSequence), false)
+const unwrapped = model.sortNodesByDelay(qmlSequence)
+assert.strictEqual(unwrapped.map(node => node.name).join(","),
+  "wrapped-fast,wrapped-slow")
+
 console.log("model tests passed")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -563,7 +563,7 @@ assert.strictEqual(tied.map(node => node.name).join(","), "x,y")
 // modelData) arrives as a sequence wrapper: `length` and indexing work and
 // `instanceof Array` is even true, but `Array.isArray` is false. The sort has
 // to accept it — this exact shape emptied every node picker in the panel
-// (probe-arrayisarray.qml reproduces the wrapper in a real QML engine).
+// (tests/probe-arrayisarray.qml reproduces the wrapper in a real QML engine).
 const qmlSequence = Object.create(Array.prototype)
 qmlSequence[0] = { name: "wrapped-slow", delay: 212 }
 qmlSequence[1] = { name: "wrapped-fast", delay: 39 }

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -509,4 +509,40 @@ assert.strictEqual(model.modeSelectionAction("direct", "rule"), "switch")
 assert.strictEqual(model.modeSelectionAction("rule", "rule"), "none")
 assert.strictEqual(model.modeSelectionAction("sideways", "rule"), "none")
 
+// -------------------------------------------------------------- node delays
+//
+// mihomo records a failed probe as delay 0, so 0 is a timeout — a node never
+// probed is NaN and reads as unknown. Neither may pass for fast.
+
+assert.strictEqual(model.delayState(1), "fast")
+assert.strictEqual(model.delayState(800), "fast")
+assert.strictEqual(model.delayState(801), "slow")
+assert.strictEqual(model.delayState(0), "timeout")
+assert.strictEqual(model.delayState(-3), "timeout")
+assert.strictEqual(model.delayState(NaN), "unknown")
+assert.strictEqual(model.delayState(undefined), "unknown")
+
+assert.strictEqual(model.formatDelay(96), "96ms")
+assert.strictEqual(model.formatDelay(96.4), "96ms")
+assert.strictEqual(model.formatDelay(0), "timeout")
+assert.strictEqual(model.formatDelay(NaN), "—")
+
+// Measured fastest-first, then the unprobed, then timeouts; ties and ranks
+// keep the subscription's own order so a quiet refresh never shuffles. The
+// model runs in a vm realm, so compare joined names rather than array identity.
+const sorted = model.sortNodesByDelay([
+  { name: "slow", delay: 1500 },
+  { name: "untested", delay: NaN },
+  { name: "fast-b", delay: 96 },
+  { name: "dead", delay: 0 },
+  { name: "fast-a", delay: 42 }
+])
+assert.strictEqual(sorted.map(node => node.name).join(","),
+  "fast-a,fast-b,slow,untested,dead")
+assert.strictEqual(model.sortNodesByDelay([]).length, 0)
+assert.strictEqual(model.sortNodesByDelay(null).length, 0)
+// Equal delays do not reorder.
+const tied = model.sortNodesByDelay([{ name: "x", delay: 100 }, { name: "y", delay: 100 }])
+assert.strictEqual(tied.map(node => node.name).join(","), "x,y")
+
 console.log("model tests passed")

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -206,6 +206,11 @@ grep -Fq 'root.service.selectModeProxy(root.draftProxy)' components/ConnectionSe
 refute -Fq 'onChanged: function(value) { root.service.selectModeProxy(value) }' components/ConnectionSection.qml
 grep -Fq 'readonly property string currentProxyGroup:' Service.qml
 grep -Fq 'ClashApi.parseProxyGroup(result.body, "PROXY")' Service.qml
+# The group name is the subscription's choice (`Proxy` as often as `PROXY`),
+# so the payload's real key is resolved and reused for the case-sensitive PUT.
+grep -Fq 'ClashApi.resolveGroupName(result.body, "PROXY")' Service.qml
+grep -Fq 'property string ruleProxyGroup: "PROXY"' Service.qml
+grep -Fq 'mode === "rule" ? ruleProxyGroup' Service.qml
 grep -Fq 'ClashApi.selectProxyCommand(apiBase, config.secret, currentProxyGroup, wanted)' Service.qml
 
 # ---- subscriptions --------------------------------------------------------

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -95,6 +95,45 @@ refute -Eq '#[0-9a-fA-F]{6}' components/Sparkline.qml
 grep -Fq 'label: "TUN"' components/ConnectionSection.qml
 grep -Fq 'root.service.liveConfigs.tunEnabled' components/ConnectionSection.qml
 
+# ---- proxy nodes ------------------------------------------------------------
+
+# The panel form of `proxy-node`: every Selector group except GLOBAL gets a
+# picker, fed from the same /proxies payload as the global options.
+grep -Fq 'NodesSection {' Panel.qml
+grep -Fq 'ClashApi.parseSelectorGroups' Service.qml
+grep -Fq 'key === "GLOBAL"' ClashApi.js
+# Node switching aims the same endpoint at any group, not just GLOBAL.
+grep -Fq 'ClashApi.selectProxyCommand(apiBase, config.secret, wantedGroup, wantedName)' Service.qml
+grep -Fq 'mihoro.selectNode(group, name)' Panel.qml
+grep -Fq 'function node(group: string, name: string): string' Panel.qml
+
+# Surge-style delay tests: one group-scoped request, fastest-first ordering,
+# and delays shown in the picker.
+grep -Fq 'ClashApi.groupDelayCommand' Service.qml
+grep -Fq 'mihoro.testGroupDelay(group)' Panel.qml
+grep -Fq 'Model.sortNodesByDelay' components/NodesSection.qml
+grep -Fq 'Model.formatDelay' components/NodesSection.qml
+grep -Fq 'text: "PROXY NODES"' components/NodesSection.qml
+# Delay colours come from the theme, never from literals.
+grep -Fq 'fastColor: systemTheme.green' Panel.qml
+grep -Fq 'slowColor: systemTheme.yellow' Panel.qml
+! grep -Eq '#[0-9a-fA-F]{6}' components/NodesSection.qml
+
+# An open picker owns the keys — its search filter accepts r, u, and friends —
+# and `n` jumps the cursor to the section.
+grep -Fq 'nodesSection.searchOpen' Panel.qml
+grep -Fq 'readonly property bool searchOpen' components/NodesSection.qml
+grep -Fq 'key === "n"' Panel.qml
+grep -Fq 'nodesSection.openGroup(target.substring(5))' Panel.qml
+
+# The TUN toggle patches the running core only; there is no tun key in
+# mihoro.toml to persist it into.
+grep -Fq 'ClashApi.setTunCommand' Service.qml
+grep -Fq 'function toggleTun()' Service.qml
+grep -Fq 'onToggled: root.service.toggleTun()' components/ConnectionSection.qml
+grep -Fq 'ToggleSwitch {' components/ConnectionSection.qml
+! grep -Fq 'tun' MihoroConfig.js
+
 # ---- subscriptions --------------------------------------------------------
 
 # URL subscriptions only: one remote config URL, fetched by the CLI.

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -172,8 +172,13 @@ grep -Fq 'interactive: root.live' components/ConnectionSection.qml
 refute -Fq 'tun' MihoroConfig.js
 # An authoritative TUN value that disagrees with the click still clears the
 # overlay once the PATCH has finished — otherwise a restart that restored
-# config.yaml would hold the toggle busy forever.
-grep -Fq '|| !tunProcess.running))' Service.qml
+# config.yaml would hold the toggle busy forever. But a /configs that started
+# before the PATCH carries the old value, so disagreement is only believed
+# from a request younger than the last completed PATCH; a straddling one is
+# re-read.
+grep -Fq 'root._tunPatchCount += 1' Service.qml
+grep -Fq 'onStarted: root._configsTunGen = root._tunPatchCount' Service.qml
+grep -Fq 'if (root._configsTunGen !== root._tunPatchCount) {' Service.qml
 sed -n '/id: optimismTimer/,/^  }/p' Service.qml | grep -Fq 'root.pendingTun = -1'
 
 # ---- subscriptions --------------------------------------------------------

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -97,11 +97,46 @@ grep -Fq 'root.service.liveConfigs.tunEnabled' components/ConnectionSection.qml
 
 # ---- proxy nodes ------------------------------------------------------------
 
-# The panel form of `proxy-node`: every Selector group except GLOBAL gets a
-# picker, fed from the same /proxies payload as the global options.
+# The panel form of `proxy-node`: every Selector group the mode row does not
+# already own gets a picker, fed from the same /proxies payload as the global
+# options.
 grep -Fq 'NodesSection {' Panel.qml
 grep -Fq 'ClashApi.parseSelectorGroups' Service.qml
 grep -Fq 'key === "GLOBAL"' ClashApi.js
+# GLOBAL is excluded at parse time; the rule group is excluded from the derived
+# list, so a mode switch moves it in or out at once. Two pickers over one group
+# would answer differently between a switch and the next refresh, and their
+# PUTs would race.
+grep -Fq 'readonly property var proxyGroups: {' Service.qml
+grep -Fq 'if (selectorGroups[i].name !== owned) out.push(selectorGroups[i])' Service.qml
+
+# The section is collapsed on every panel open: a few groups are three lines
+# each, and the panel belongs to the people who never change a node. Shut, the
+# section is one cursor target that opens it; open, each group is its own.
+grep -Fq 'property bool nodesExpanded: false' Panel.qml
+grep -Fq 'nodesExpanded = false' Panel.qml
+grep -Fq 'expanded: root.nodesExpanded' Panel.qml
+grep -Fq 'list.push("nodes")' Panel.qml
+grep -Fq 'if (nodesExpanded)' Panel.qml
+grep -Fq 'headerCursor: root.cursorTarget === "nodes"' Panel.qml
+grep -Fq 'onToggleRequested: root.nodesExpanded = !root.nodesExpanded' Panel.qml
+grep -Fq 'CursorSurface {' components/NodesSection.qml
+
+# A pick is a draft until Apply, exactly as the mode row's proxy is. Switching
+# on selection fires a PUT at whatever the search filter lands on mid-typing.
+grep -Fq 'text: "Apply"' components/NodesSection.qml
+grep -Fq 'text: "Cancel"' components/NodesSection.qml
+grep -Fq 'onClicked: groupRow.apply()' components/NodesSection.qml
+grep -Fq 'root.nodeRequested(groupName, draftNode)' components/NodesSection.qml
+refute -Fq 'onChanged: function(value) { root.nodeRequested(' components/NodesSection.qml
+
+# The Repeater is keyed on group names, not on the group objects: a delegate
+# model over a JS array is rebuilt whenever its contents change, and the groups
+# carry the delays — so a delay test would destroy the open picker and the
+# draft inside it at the moment its own numbers arrived.
+grep -Fq 'readonly property var groupNames:' components/NodesSection.qml
+grep -Fq 'model: root.expanded ? root.groupNames : []' components/NodesSection.qml
+refute -Eq 'model: root\.groups *$' components/NodesSection.qml
 # Node switching aims the same endpoint at any group, not just GLOBAL.
 grep -Fq 'ClashApi.selectProxyCommand(apiBase, config.secret, wantedGroup, wantedName)' Service.qml
 grep -Fq 'mihoro.selectNode(group, name)' Panel.qml
@@ -111,7 +146,10 @@ grep -Fq 'function node(group: string, name: string): string' Panel.qml
 # the mode switch has, so both are gated on the API actually answering, and the
 # pickers go quiet when it does not.
 grep -Fq 'if (connection.key !== "running") return' Service.qml
-grep -Fq 'if (wanted === "" || connection.key !== "running" || delayProcess.running) return' Service.qml
+grep -Fq 'if (wanted === "" || connection.key !== "running") return' Service.qml
+# The bolt buttons grey out during a test, so only `d` can arrive mid-test: it
+# says which group is busy rather than doing nothing.
+grep -Fq 'actionStatus = "Testing " + testingDelayGroup' Service.qml
 grep -Fq 'switchable: mihoro.connection.key === "running"' Panel.qml
 grep -Fq 'enabled: root.switchable' components/NodesSection.qml
 
@@ -150,7 +188,7 @@ refute -Eq '#[0-9a-fA-F]{6}' components/NodesSection.qml
 grep -Fq 'nodesSection.searchOpen' Panel.qml
 grep -Fq 'readonly property bool searchOpen' components/NodesSection.qml
 grep -Fq 'key === "n"' Panel.qml
-grep -Fq 'nodesSection.openGroup(target.substring(5))' Panel.qml
+grep -Fq 'nodesSection.activateGroup(target.substring(5))' Panel.qml
 
 # Every mouse-reachable action has a key: `d` tests the group under the cursor,
 # `u` toggles TUN, and the TUN row is a cursor target.
@@ -160,12 +198,21 @@ grep -Fq 'mihoro.testGroupDelay(root.cursorTarget.substring(5))' Panel.qml
 grep -Fq 'list.push("tun")' Panel.qml
 grep -Fq 'tunCursor: root.cursorTarget === "tun"' Panel.qml
 grep -Fq 'hasCursor: root.tunCursor' components/ConnectionSection.qml
+# `hasCursor` reaches nothing in ToggleSwitch but the cursor ring, so
+# suppressing the ring left the cursor invisible on the row it is aimed at. The
+# target itself is only there while the core answers, since the switch is inert
+# otherwise.
+refute -Fq 'cursorRing: false' components/ConnectionSection.qml
+grep -Fq '&& mihoro.connection.key === "running") list.push("tun")' Panel.qml
 
 # The TUN toggle patches the running core only; there is no tun key in
 # mihoro.toml to persist it into. A stopped core keeps its last liveConfigs, so
 # the switch goes quiet with the service rather than discarding clicks.
 grep -Fq 'ClashApi.setTunCommand' Service.qml
 grep -Fq 'function toggleTun()' Service.qml
+# Toggle what is on screen: the overlay outlives the PATCH by a round trip, and
+# reading liveConfigs there made a second press re-send the first one's value.
+grep -Fq 'pendingTun = (pendingTun !== -1 ? pendingTun === 1 : liveConfigs.tunEnabled === true) ? 0 : 1' Service.qml
 grep -Fq 'onToggled: root.service.toggleTun()' components/ConnectionSection.qml
 grep -Fq 'ToggleSwitch {' components/ConnectionSection.qml
 grep -Fq 'interactive: root.live' components/ConnectionSection.qml
@@ -209,6 +256,10 @@ grep -Fq 'ClashApi.parseProxyGroup(result.body, "PROXY")' Service.qml
 # The group name is the subscription's choice (`Proxy` as often as `PROXY`),
 # so the payload's real key is resolved and reused for the case-sensitive PUT.
 grep -Fq 'ClashApi.resolveGroupName(result.body, "PROXY")' Service.qml
+# Resolving the key must not re-parse the body: /proxies is the largest payload
+# the panel reads, and parseProxyGroup already has it parsed.
+grep -Fq 'groupKeyIn(proxies, groupName)' ClashApi.js
+refute -Fq 'resolveGroupName(body, groupName)' ClashApi.js
 grep -Fq 'property string ruleProxyGroup: "PROXY"' Service.qml
 grep -Fq 'mode === "rule" ? ruleProxyGroup' Service.qml
 grep -Fq 'ClashApi.selectProxyCommand(apiBase, config.secret, currentProxyGroup, wanted)' Service.qml
@@ -578,5 +629,10 @@ refute -rEq 'console\.(log|warn|error).*(secret|remoteConfigUrl|remote_config_ur
   Panel.qml Service.qml components/*.qml Model.js ClashApi.js MihoroConfig.js Subscriptions.js
 # Clipboard data is written over stdin, never embedded in a command argument.
 refute -rEq 'execDetached\(.*wl-copy|bash.*wl-copy' Panel.qml Service.qml components/*.qml
+
+# The QML probe behind the sequence-wrapper fix is a test artefact, not part of
+# the plugin.
+[[ ! -e probe-arrayisarray.qml ]]
+[[ -e tests/probe-arrayisarray.qml ]]
 
 echo "panel source tests passed"

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -107,6 +107,32 @@ grep -Fq 'ClashApi.selectProxyCommand(apiBase, config.secret, wantedGroup, wante
 grep -Fq 'mihoro.selectNode(group, name)' Panel.qml
 grep -Fq 'function node(group: string, name: string): string' Panel.qml
 
+# Node switching and delay tests are API-only: no `mihoro apply` fallback like
+# the mode switch has, so both are gated on the API actually answering, and the
+# pickers go quiet when it does not.
+grep -Fq 'if (connection.key !== "running") return' Service.qml
+grep -Fq 'if (wanted === "" || connection.key !== "running" || delayProcess.running) return' Service.qml
+grep -Fq 'switchable: mihoro.connection.key === "running"' Panel.qml
+grep -Fq 'enabled: root.switchable' components/NodesSection.qml
+
+# A second pick while one is in flight is queued (latest wins), never dropped.
+grep -Fq '_queuedNode = { group: wantedGroup, name: wantedName }' Service.qml
+grep -Fq 'if (queued !== null) root.selectNode(queued.group, queued.name)' Service.qml
+
+# The optimistic overlay outlives the PUT: it clears when /proxies confirms it
+# or when the optimism deadline drops it — never right after the request, which
+# would snap the picker back to the stale `now`.
+sed -n '/id: optimismTimer/,/^  }/p' Service.qml | grep -Fq 'root.pendingNode = null'
+grep -Fq 'groups[i].now === root.pendingNode.name' Service.qml
+nodeSelect=$(sed -n '/id: nodeSelectProcess/,/^  }/p' Service.qml)
+[[ "$nodeSelect" != *$'root.pendingNode = null\n        root.refreshProxies()'* ]]
+
+# The watchdog is for polls, not actions: its 12s fuse is tied to the refresh
+# that armed it, not to an action's start, and would reap a healthy 10s delay
+# test. Actions bound themselves with curl's --max-time.
+watchdog=$(sed -n '/id: pollWatchdog/,/^  }/p' Service.qml)
+[[ "$watchdog" != *nodeSelectProcess* && "$watchdog" != *delayProcess* && "$watchdog" != *tunProcess* ]]
+
 # Surge-style delay tests: one group-scoped request, fastest-first ordering,
 # and delays shown in the picker.
 grep -Fq 'ClashApi.groupDelayCommand' Service.qml
@@ -117,7 +143,7 @@ grep -Fq 'text: "PROXY NODES"' components/NodesSection.qml
 # Delay colours come from the theme, never from literals.
 grep -Fq 'fastColor: systemTheme.green' Panel.qml
 grep -Fq 'slowColor: systemTheme.yellow' Panel.qml
-! grep -Eq '#[0-9a-fA-F]{6}' components/NodesSection.qml
+refute -Eq '#[0-9a-fA-F]{6}' components/NodesSection.qml
 
 # An open picker owns the keys — its search filter accepts r, u, and friends —
 # and `n` jumps the cursor to the section.
@@ -126,13 +152,29 @@ grep -Fq 'readonly property bool searchOpen' components/NodesSection.qml
 grep -Fq 'key === "n"' Panel.qml
 grep -Fq 'nodesSection.openGroup(target.substring(5))' Panel.qml
 
+# Every mouse-reachable action has a key: `d` tests the group under the cursor,
+# `u` toggles TUN, and the TUN row is a cursor target.
+grep -Fq 'key === "d"' Panel.qml
+grep -Fq 'key === "u"' Panel.qml
+grep -Fq 'mihoro.testGroupDelay(root.cursorTarget.substring(5))' Panel.qml
+grep -Fq 'list.push("tun")' Panel.qml
+grep -Fq 'tunCursor: root.cursorTarget === "tun"' Panel.qml
+grep -Fq 'hasCursor: root.tunCursor' components/ConnectionSection.qml
+
 # The TUN toggle patches the running core only; there is no tun key in
-# mihoro.toml to persist it into.
+# mihoro.toml to persist it into. A stopped core keeps its last liveConfigs, so
+# the switch goes quiet with the service rather than discarding clicks.
 grep -Fq 'ClashApi.setTunCommand' Service.qml
 grep -Fq 'function toggleTun()' Service.qml
 grep -Fq 'onToggled: root.service.toggleTun()' components/ConnectionSection.qml
 grep -Fq 'ToggleSwitch {' components/ConnectionSection.qml
-! grep -Fq 'tun' MihoroConfig.js
+grep -Fq 'interactive: root.live' components/ConnectionSection.qml
+refute -Fq 'tun' MihoroConfig.js
+# An authoritative TUN value that disagrees with the click still clears the
+# overlay once the PATCH has finished — otherwise a restart that restored
+# config.yaml would hold the toggle busy forever.
+grep -Fq '|| !tunProcess.running))' Service.qml
+sed -n '/id: optimismTimer/,/^  }/p' Service.qml | grep -Fq 'root.pendingTun = -1'
 
 # ---- subscriptions --------------------------------------------------------
 

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -251,6 +251,12 @@ if not block or "bordered: true" not in block.group(1):
 print("proxy cancel outline ok")
 PROXY_CANCEL
 grep -Fq 'root.service.selectModeProxy(root.draftProxy)' components/ConnectionSection.qml
+# SearchableDropdown assigns its own `value` when a row is picked, which
+# destroys the binding the caller installed. Every picker puts it back, or
+# Cancel clears the draft while the picked node stays in the trigger.
+grep -Fq 'proxyPicker.value = Qt.binding(function() { return root.draftProxy })' components/ConnectionSection.qml
+grep -Fq 'globalPicker.value = Qt.binding(function() { return root.currentProxy })' components/ModeSection.qml
+grep -Fq 'dropdown.value = Qt.binding(function() { return groupRow.pickerValue })' components/NodesSection.qml
 refute -Fq 'onChanged: function(value) { root.service.selectModeProxy(value) }' components/ConnectionSection.qml
 grep -Fq 'readonly property string currentProxyGroup:' Service.qml
 grep -Fq 'ClashApi.parseProxyGroup(result.body, "PROXY")' Service.qml
@@ -350,14 +356,15 @@ grep -Fq 'iconSize: Style.space(12)' Panel.qml
 grep -Fq 'onCopyProxyRequested: mihoro.copyProxyExport()' Panel.qml
 grep -Fq 'text: "Copy proxy export"' components/PanelMenu.qml
 grep -Fq 'https://github.com/huacnlee/omarchy-mihoro' components/PanelMenu.qml
-grep -Fq 'text: "Mihoro docs..."' components/PanelMenu.qml
+# mihoro's own README is the install guide, reached from the install page; the
+# menu does not carry a second link to it.
+refute -Fq 'text: "Mihoro docs..."' components/PanelMenu.qml
+refute -Fq 'Model.INSTALL_DOCS_URL' components/PanelMenu.qml
 refute -Fq 'text: "Install Guides"' components/PanelMenu.qml
 refute -Fq 'text: "Open install guide"' components/PanelMenu.qml
-grep -Fq 'Model.INSTALL_DOCS_URL' components/PanelMenu.qml
 grep -Fq 'text: "Dashboard..."' components/PanelMenu.qml
 grep -Fq 'text: "GitHub..."' components/PanelMenu.qml
 grep -Fq 'text: "Mihoro..."; onActivated: root.openUrl(Model.PROJECT_URL)' components/PanelMenu.qml
-grep -Fq 'text: "Mihoro docs..."' components/PanelMenu.qml
 grep -Fq 'text: "Mihoro..."' components/PanelMenu.qml
 refute -Fq 'text: "mihoro"' components/PanelMenu.qml
 refute -Fq 'text: "Mihoro Docs"' components/PanelMenu.qml

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -92,8 +92,11 @@ refute -Fq 'root.downHistory = []' Service.qml
 refute -Eq 'bezierCurveTo|quadraticCurveTo' components/Sparkline.qml
 refute -Eq '#[0-9a-fA-F]{6}' components/Sparkline.qml
 
+# TUN reads as a stat here and acts from the menu. A switch inside an otherwise
+# read-only block put a state change one stray click away.
 grep -Fq 'label: "TUN"' components/ConnectionSection.qml
-grep -Fq 'root.service.liveConfigs.tunEnabled' components/ConnectionSection.qml
+grep -Fq 'root.service.tunState' components/ConnectionSection.qml
+refute -Fq 'ToggleSwitch {' components/ConnectionSection.qml
 
 # ---- proxy nodes ------------------------------------------------------------
 
@@ -110,17 +113,20 @@ grep -Fq 'key === "GLOBAL"' ClashApi.js
 grep -Fq 'readonly property var proxyGroups: {' Service.qml
 grep -Fq 'if (selectorGroups[i].name !== owned) out.push(selectorGroups[i])' Service.qml
 
-# The section is collapsed on every panel open: a few groups are three lines
-# each, and the panel belongs to the people who never change a node. Shut, the
-# section is one cursor target that opens it; open, each group is its own.
+# Folded away on every panel open, behind the icon beside the mode chips: a few
+# groups are three lines each, and the panel belongs to the people who never
+# change a node. Nothing of the section is on screen until it is asked for — not
+# even its header — and only the groups actually drawn are cursor targets.
 grep -Fq 'property bool nodesExpanded: false' Panel.qml
 grep -Fq 'nodesExpanded = false' Panel.qml
 grep -Fq 'expanded: root.nodesExpanded' Panel.qml
-grep -Fq 'list.push("nodes")' Panel.qml
 grep -Fq 'if (nodesExpanded)' Panel.qml
-grep -Fq 'headerCursor: root.cursorTarget === "nodes"' Panel.qml
-grep -Fq 'onToggleRequested: root.nodesExpanded = !root.nodesExpanded' Panel.qml
-grep -Fq 'CursorSurface {' components/NodesSection.qml
+refute -Fq 'list.push("nodes")' Panel.qml
+grep -Fq 'nodesAvailable: mihoro.proxyGroups.length > 0' Panel.qml
+grep -Fq 'onNodesToggleRequested: root.nodesExpanded = !root.nodesExpanded' Panel.qml
+grep -Fq 'id: nodesButton' components/ModeSection.qml
+grep -Fq 'name: root.nodesExpanded ? "arrow-up" : "arrow-down"' components/ModeSection.qml
+refute -Fq 'CursorSurface' components/NodesSection.qml
 
 # A pick is a draft until Apply, exactly as the mode row's proxy is. Switching
 # on selection fires a PUT at whatever the search filter lands on mid-typing.
@@ -190,32 +196,27 @@ grep -Fq 'readonly property bool searchOpen' components/NodesSection.qml
 grep -Fq 'key === "n"' Panel.qml
 grep -Fq 'nodesSection.activateGroup(target.substring(5))' Panel.qml
 
-# Every mouse-reachable action has a key: `d` tests the group under the cursor,
-# `u` toggles TUN, and the TUN row is a cursor target.
+# Every mouse-reachable action has a key: `d` tests the group under the cursor
+# and `u` toggles TUN, whose mouse path is the menu row.
 grep -Fq 'key === "d"' Panel.qml
 grep -Fq 'key === "u"' Panel.qml
 grep -Fq 'mihoro.testGroupDelay(root.cursorTarget.substring(5))' Panel.qml
-grep -Fq 'list.push("tun")' Panel.qml
-grep -Fq 'tunCursor: root.cursorTarget === "tun"' Panel.qml
-grep -Fq 'hasCursor: root.tunCursor' components/ConnectionSection.qml
-# `hasCursor` reaches nothing in ToggleSwitch but the cursor ring, so
-# suppressing the ring left the cursor invisible on the row it is aimed at. The
-# target itself is only there while the core answers, since the switch is inert
-# otherwise.
-refute -Fq 'cursorRing: false' components/ConnectionSection.qml
-grep -Fq '&& mihoro.connection.key === "running") list.push("tun")' Panel.qml
+refute -Fq 'list.push("tun")' Panel.qml
+grep -Fq 'text: root.tunEnabled ? "Disable TUN" : "Enable TUN"' components/PanelMenu.qml
+grep -Fq 'onTunRequested: mihoro.toggleTun()' Panel.qml
+grep -Fq 'canToggleTun: mihoro.canToggleTun' Panel.qml
 
 # The TUN toggle patches the running core only; there is no tun key in
 # mihoro.toml to persist it into. A stopped core keeps its last liveConfigs, so
 # the switch goes quiet with the service rather than discarding clicks.
 grep -Fq 'ClashApi.setTunCommand' Service.qml
 grep -Fq 'function toggleTun()' Service.qml
-# Toggle what is on screen: the overlay outlives the PATCH by a round trip, and
-# reading liveConfigs there made a second press re-send the first one's value.
-grep -Fq 'pendingTun = (pendingTun !== -1 ? pendingTun === 1 : liveConfigs.tunEnabled === true) ? 0 : 1' Service.qml
-grep -Fq 'onToggled: root.service.toggleTun()' components/ConnectionSection.qml
-grep -Fq 'ToggleSwitch {' components/ConnectionSection.qml
-grep -Fq 'interactive: root.live' components/ConnectionSection.qml
+# One effective state feeds the stat row, the menu label, and the toggle, so
+# none of them can disagree. Toggling reads it rather than liveConfigs: the
+# overlay outlives the PATCH by a round trip, and reading the last /configs
+# there made a second press re-send the first one's value.
+grep -Fq 'readonly property var tunState:' Service.qml
+grep -Fq 'pendingTun = tunState === true ? 0 : 1' Service.qml
 refute -Fq 'tun' MihoroConfig.js
 # An authoritative TUN value that disagrees with the click still clears the
 # overlay once the PATCH has finished — otherwise a restart that restored


### PR DESCRIPTION
## What

- **Proxy-node switching** (`proxy-node` style): a new PROXY NODES section lists every Selector group except GLOBAL (which the mode chips own) with a searchable dropdown per group, switching via `PUT /proxies/{group}`. Keyboard: `n` jumps to the section, `d` tests the group under the cursor; an open picker's search owns the keys. IPC gains `node(group, name)`.
- **Latency test, Surge-style**: nodes show their last measured delay from the core's probe history; a bolt-button per group runs `/group/{name}/delay` and re-sorts fastest-first (untested, then timeouts last). The current node's delay is colored with theme green/yellow via `SystemTheme` — no hard-coded colors, and the value is always printed beside the color.
- **TUN toggle**: the TUN stat row becomes a switch that patches the running core via `PATCH /configs {"tun":{...}}`. Runtime-only (mihoro.toml has no `tun` key); the tooltip says a restart restores `config.yaml`. `u` toggles it from the keyboard, and the row is a cursor target.

## How

- `ClashApi.js`: `groupDelayCommand`, `setTunCommand`, `parseSelectorGroups` (GLOBAL excluded; delay = last history entry, NaN when never probed), `parseGroupDelay`. mihomo records failed probes as delay 0, so 0 renders as timeout, never as fast.
- `Model.js`: `delayState` / `formatDelay` / `sortNodesByDelay` (measured ascending, then unprobed, then timeouts; ties keep subscription order).
- `Service.qml`: groups parsed from the existing `/proxies` poll; node-select, delay-test, and TUN processes with the same optimistic-overlay pattern as mode switching. Overlays clear only when a refresh confirms them or the optimism deadline drops them; a second node pick while one is in flight is queued (latest wins); API-only actions are gated on `connection.key === "running"`; a `/configs` response that straddles the TUN PATCH is detected by a generation counter and re-read rather than believed.
- New `components/NodesSection.qml`; TUN toggle in `components/ConnectionSection.qml`; a `bolt` glyph added to the shared `ActionIcon` set (drawn, not a text glyph, per DESIGN.md).
- `DESIGN.md` documents the new surface: delay color semantics, `node:<group>` cursor targets, key ownership while a picker is open, and the polls-only watchdog rule.

## Verification

- `make validate` passes: node unit tests for the new parsers and delay ordering, `test_panel_source.sh` pins for every decision above (negative checks via `refute`), qmllint, `omarchy plugin validate`.
- Live smoke test against a running mihomo v1.19.30: `/proxies` groups parsed, `/group/<group>/delay` returned fresh measurements, a no-op `PUT /proxies/<group>` and an idempotent TUN PATCH both returned 204, and `omarchy-shell mihoro.omarchy node <group> <name>` works end-to-end.
