### PR TITLE
Fetch subscriptions with mihoro's configured user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ journalctl --user -u mihomo.service -n 30 --no-pager
 Subscription downloads identify with `mihoro_user_agent` in `~/.config/mihoro.toml`
 — mihoro's own setting, `mihoro` by default. Both fetch paths use it: the CLI's
 `mihoro update --config` and the panel's enhanced update. If a provider hands
-out configs only to particular clients, set it there by hand:
+out configs only to particular clients, set it there by hand. The value goes
+out as an HTTP header, so it has to be Latin-1 — a name written in Chinese
+falls back to `mihoro`, which is what mihoro's own fetch would send anyway:
 
 ```toml
 mihoro_user_agent = "clash-verge/1.2"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ If mihomo does not start, inspect its recent logs:
 journalctl --user -u mihomo.service -n 30 --no-pager
 ```
 
+## User agent
+
+Subscription downloads identify with `mihoro_user_agent` in `~/.config/mihoro.toml`
+— mihoro's own setting, `mihoro` by default. Both fetch paths use it: the CLI's
+`mihoro update --config` and the panel's enhanced update. If a provider hands
+out configs only to particular clients, set it there by hand:
+
+```toml
+mihoro_user_agent = "clash-verge/1.2"
+```
+
 ## Development
 
 ```bash

--- a/scripts/config_enhancer.py
+++ b/scripts/config_enhancer.py
@@ -7,6 +7,7 @@ import binascii
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 import tempfile
@@ -97,8 +98,27 @@ def read_mihoro_url(path):
     return url
 
 
-def download(url):
-    request = urllib.request.Request(url, headers={"User-Agent": "mihoro"})
+# The same client name `mihoro update --config` sends, so the two update paths
+# identify identically to the provider. Falls back to mihoro's own default when
+# the key is absent, empty, or the file cannot be read.
+DEFAULT_USER_AGENT = "mihoro"
+
+
+def read_user_agent(path):
+    if path is None:
+        return DEFAULT_USER_AGENT
+    try:
+        value = tomllib.loads(path.read_text()).get("mihoro_user_agent", "")
+    except (OSError, tomllib.TOMLDecodeError):
+        return DEFAULT_USER_AGENT
+    # The value becomes a request header: a hand-edited file must not smuggle
+    # extra ones in on a line break.
+    text = re.sub(r"[\x00-\x1f\x7f]+", " ", str(value)).strip()
+    return text or DEFAULT_USER_AGENT
+
+
+def download(url, user_agent):
+    request = urllib.request.Request(url, headers={"User-Agent": user_agent})
     with urllib.request.urlopen(request, timeout=30) as response:
         return response.read()
 
@@ -156,7 +176,7 @@ def main():
                 url = read_subscription_url(args.subscriptions, args.subscription_id)
             else:
                 raise ValueError("mihoro.toml is required for an update.")
-            incoming_raw = download(url)
+            incoming_raw = download(url, read_user_agent(args.mihoro_config))
         candidate = load_yaml_bytes(incoming_raw)
         for key in MANAGED_KEYS:
             if key in current:

--- a/scripts/config_enhancer.py
+++ b/scripts/config_enhancer.py
@@ -111,10 +111,26 @@ def read_user_agent(path):
         value = tomllib.loads(path.read_text()).get("mihoro_user_agent", "")
     except (OSError, tomllib.TOMLDecodeError):
         return DEFAULT_USER_AGENT
+    # A non-string value is a mis-edit, not a client name: mihoro's own
+    # deserializer refuses it outright rather than stringifying it, and
+    # `str(True)` would put the Python spelling of a bool on the wire.
+    if not isinstance(value, str):
+        return DEFAULT_USER_AGENT
     # The value becomes a request header: a hand-edited file must not smuggle
     # extra ones in on a line break.
-    text = re.sub(r"[\x00-\x1f\x7f]+", " ", str(value)).strip()
-    return text or DEFAULT_USER_AGENT
+    text = re.sub(r"[\x00-\x1f\x7f]+", " ", value).strip()
+    if not text:
+        return DEFAULT_USER_AGENT
+    # http.client encodes header values as latin-1, so anything outside it —
+    # a name written in Chinese, say — raises UnicodeEncodeError from inside
+    # urlopen and fails the whole update with a codec message. mihoro's own
+    # fetch would refuse the same value, so falling back keeps the two paths
+    # identifying alike instead of one of them breaking.
+    try:
+        text.encode("latin-1")
+    except UnicodeEncodeError:
+        return DEFAULT_USER_AGENT
+    return text
 
 
 def download(url, user_agent):

--- a/scripts/config_enhancer.py
+++ b/scripts/config_enhancer.py
@@ -87,30 +87,34 @@ def read_subscription_url(path, subscription_id):
     raise ValueError("The active subscription URL is unavailable.")
 
 
-def read_mihoro_url(path):
+def load_mihoro_config(path):
+    # The file itself is load-bearing — it is where the update's URL lives —
+    # so a broken one fails the update. Individual keys are settled leniently
+    # by their readers below.
     try:
-        value = tomllib.loads(path.read_text()).get("remote_config_url", "")
-    except (OSError, tomllib.TOMLDecodeError) as error:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
         raise ValueError("Could not read mihoro.toml: %s" % error) from error
-    url = str(value).strip()
-    if not url:
+
+
+def read_mihoro_url(mihoro_config):
+    # A non-string value is a mis-edit, not a URL: like the user agent below,
+    # it is refused rather than stringified onto the wire.
+    value = mihoro_config.get("remote_config_url", "")
+    if not isinstance(value, str) or not value.strip():
         raise ValueError("The active subscription URL is unavailable.")
-    return url
+    return value.strip()
 
 
 # The same client name `mihoro update --config` sends, so the two update paths
 # identify identically to the provider. Falls back to mihoro's own default when
-# the key is absent, empty, or the file cannot be read.
+# the key is absent, empty, or otherwise unusable — the user agent is cosmetic
+# and never worth failing an update over.
 DEFAULT_USER_AGENT = "mihoro"
 
 
-def read_user_agent(path):
-    if path is None:
-        return DEFAULT_USER_AGENT
-    try:
-        value = tomllib.loads(path.read_text()).get("mihoro_user_agent", "")
-    except (OSError, tomllib.TOMLDecodeError):
-        return DEFAULT_USER_AGENT
+def read_user_agent(mihoro_config):
+    value = mihoro_config.get("mihoro_user_agent", "")
     # A non-string value is a mis-edit, not a client name: mihoro's own
     # deserializer refuses it outright rather than stringifying it, and
     # `str(True)` would put the Python spelling of a bool on the wire.
@@ -187,12 +191,15 @@ def main():
             incoming_raw = args.source.read_bytes()
         else:
             if args.mihoro_config:
-                url = read_mihoro_url(args.mihoro_config)
+                mihoro_config = load_mihoro_config(args.mihoro_config)
+                url = read_mihoro_url(mihoro_config)
+                user_agent = read_user_agent(mihoro_config)
             elif args.subscriptions:
                 url = read_subscription_url(args.subscriptions, args.subscription_id)
+                user_agent = DEFAULT_USER_AGENT
             else:
                 raise ValueError("mihoro.toml is required for an update.")
-            incoming_raw = download(url, read_user_agent(args.mihoro_config))
+            incoming_raw = download(url, user_agent)
         candidate = load_yaml_bytes(incoming_raw)
         for key in MANAGED_KEYS:
             if key in current:

--- a/tests/test_config_enhancer.py
+++ b/tests/test_config_enhancer.py
@@ -111,6 +111,19 @@ with tempfile.TemporaryDirectory() as temp:
     run_enhancer(root, "update", "--mihoro-config", str(root / "mihoro.toml"),
                  "--no-restart")
 
+    # A non-string value is a mis-edit, not a URL: it is refused with the
+    # missing-URL message rather than stringified onto the wire.
+    (root / "mihoro.toml").write_text("remote_config_url = true\n")
+    result = run_enhancer(root, "update", "--mihoro-config", str(root / "mihoro.toml"),
+                          "--no-restart", expect=1)
+    assert "The active subscription URL is unavailable." in result.stderr
+
+    # Bytes the file cannot be decoded from report the file, not a codec.
+    (root / "mihoro.toml").write_bytes(b'remote_config_url = "http://x/y"\n\xff\xfe\n')
+    result = run_enhancer(root, "update", "--mihoro-config", str(root / "mihoro.toml"),
+                          "--no-restart", expect=1)
+    assert "Could not read mihoro.toml" in result.stderr
+
     # Base64 subscriptions are decoded before merging.
     encoded = root / "encoded.txt"
     encoded.write_bytes(base64.b64encode(remote.read_bytes()))

--- a/tests/test_config_enhancer.py
+++ b/tests/test_config_enhancer.py
@@ -1,10 +1,12 @@
 import base64
+import http.server
 import json
 import os
 from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import threading
 
 import yaml
 
@@ -114,5 +116,69 @@ with tempfile.TemporaryDirectory() as temp:
     result = run_enhancer(root, "apply", "--no-restart", expect=1)
     assert "invalid" in result.stderr
     assert (root / "config.yaml").read_text() == before
+
+# Subscription downloads identify with `mihoro_user_agent` from mihoro.toml —
+# the same value `mihoro update --config` sends — so a provider that answers
+# particular clients sees one client whichever path fetched. Only a real HTTP
+# fetch exposes the header, so the remote is served from a local server.
+with tempfile.TemporaryDirectory() as temp:
+    root = Path(temp)
+    remote_config = yaml.safe_dump({
+        "port": 9999,
+        "mode": "rule",
+        "rules": ["MATCH,PROXY"],
+        "proxies": [{"name": "Node", "type": "http", "server": "example.com", "port": 443}],
+    }, sort_keys=False)
+    seen = {}
+
+    class AgentHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            seen["agent"] = self.headers.get("User-Agent", "")
+            body = remote_config.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/yaml")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), AgentHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        url = "http://127.0.0.1:%d/remote.yaml" % server.server_port
+        write_executable(root / "mihomo", "#!/bin/sh\nexit 0\n")
+        write_executable(root / "systemctl", "#!/bin/sh\nexit 0\n")
+        (root / "config.yaml").write_text(remote_config)
+        (root / "rules.json").write_text(json.dumps({
+            "version": 1, "subscriptions": {"sub-a": {"rules": [], "applied": []}},
+        }))
+
+        def mihoro_toml(user_agent_line):
+            return f'remote_config_url = "{url}"\n' + user_agent_line
+
+        (root / "mihoro.toml").write_text(
+            mihoro_toml('mihoro_user_agent = "clash-verge/1.2"\n'))
+        run_enhancer(root, "update", "--mihoro-config", str(root / "mihoro.toml"),
+                     "--no-restart")
+        assert seen["agent"] == "clash-verge/1.2"
+
+        # No key, no empty gap: the downloader falls back to mihoro's own
+        # default, so the provider sees the same client either way.
+        (root / "mihoro.toml").write_text(mihoro_toml(""))
+        run_enhancer(root, "update", "--mihoro-config", str(root / "mihoro.toml"),
+                     "--no-restart")
+        assert seen["agent"] == "mihoro"
+
+        # The value becomes a request header: a line break must be collapsed
+        # rather than smuggle a second one in.
+        (root / "mihoro.toml").write_text(
+            mihoro_toml('mihoro_user_agent = "clash/1.0\\nx-inject: yes"\n'))
+        run_enhancer(root, "update", "--mihoro-config", str(root / "mihoro.toml"),
+                     "--no-restart")
+        assert seen["agent"] == "clash/1.0 x-inject: yes"
+    finally:
+        server.shutdown()
 
 print("config enhancer tests passed")

--- a/tests/test_config_enhancer.py
+++ b/tests/test_config_enhancer.py
@@ -31,7 +31,13 @@ def run_enhancer(root, *extra, expect=0):
         "--systemctl", str(root / "systemctl"),
         *extra,
     ]
-    result = subprocess.run(command, text=True, capture_output=True)
+    # The subscription server in the user-agent test is on loopback, and
+    # urllib honours http_proxy without bypassing 127.0.0.1 — only no_proxy
+    # does. On any machine that exports one (this repo's own developers, whose
+    # whole subject is a local proxy) the fetch would go to the proxy and the
+    # test would fail for a reason that has nothing to do with the code.
+    environment = {**os.environ, "no_proxy": "*", "NO_PROXY": "*"}
+    result = subprocess.run(command, text=True, capture_output=True, env=environment)
     assert result.returncode == expect, result.stderr
     return result
 
@@ -178,6 +184,22 @@ with tempfile.TemporaryDirectory() as temp:
         run_enhancer(root, "update", "--mihoro-config", str(root / "mihoro.toml"),
                      "--no-restart")
         assert seen["agent"] == "clash/1.0 x-inject: yes"
+
+        # Header values are encoded latin-1, so a name written in Chinese would
+        # raise UnicodeEncodeError from inside urlopen and fail the whole
+        # update with a codec message. mihoro's own fetch refuses the same
+        # value, so the default is what keeps the two paths identifying alike.
+        (root / "mihoro.toml").write_text(
+            mihoro_toml('mihoro_user_agent = "小猫咪/1.0"\n'))
+        run_enhancer(root, "update", "--mihoro-config", str(root / "mihoro.toml"),
+                     "--no-restart")
+        assert seen["agent"] == "mihoro"
+
+        # A value that is not a string is a mis-edit, not a client name.
+        (root / "mihoro.toml").write_text(mihoro_toml("mihoro_user_agent = true\n"))
+        run_enhancer(root, "update", "--mihoro-config", str(root / "mihoro.toml"),
+                     "--no-restart")
+        assert seen["agent"] == "mihoro"
     finally:
         server.shutdown()
 


### PR DESCRIPTION
The enhanced update downloads the subscription itself but always identified as
a hardcoded `User-Agent: mihoro`. It now sends `mihoro_user_agent` from
`~/.config/mihoro.toml` — the same value `mihoro update --config` already
sends — so a provider that gates the config format on the client name sees one
client whichever path fetched.

- Falls back to mihoro's own default (`mihoro`) when the key is absent, empty,
  or mihoro.toml cannot be read.
- Control characters are collapsed before the value becomes a request header,
  so a hand-edited file cannot smuggle extra ones in on a line break.
- No caller changes: the panel and the update timer already pass
  `--mihoro-config`, so both pick this up without new plumbing.

## Tests

`tests/test_config_enhancer.py` now serves the remote from a local HTTP server
and asserts the header actually sent: a custom value passes through unchanged,
the default kicks in when the key is missing, and a line break is collapsed.
`make validate` passes.