### PR TITLE
Move proxy edit action beside the selected proxy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -196,7 +196,8 @@ A subscription URL is a bearer token — the whole of the authentication.
   confirmed.
 - The connection facts name the selectable node on its own `Proxy` label/value
   row. In Rule mode that means the live `PROXY` selector; in Global mode it
-  means `GLOBAL`; Direct has no selector and says `DIRECT`. Editing expands the
+  means `GLOBAL`; Direct has no selector and says `DIRECT`. The edit icon sits
+  immediately before the right-aligned proxy value. Editing expands the
   row into a searchable picker, but choosing only stages a value: `Apply`
   changes the running core and `Cancel` leaves it alone. Success returns to the
   label/value row; failure leaves the editor open so the choice can be retried.

--- a/components/ConnectionSection.qml
+++ b/components/ConnectionSection.qml
@@ -131,8 +131,8 @@ Column {
 
       PanelActionButton {
         id: editProxy
-        anchors.left: proxyLabel.right
-        anchors.leftMargin: Style.space(4)
+        anchors.right: proxyValue.left
+        anchors.rightMargin: Style.space(4)
         anchors.verticalCenter: parent.verticalCenter
         visible: root.live && root.service.currentProxyGroup !== ""
         size: Style.space(20)

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -239,7 +239,7 @@ grep -Fq 'property bool editingProxy: false' components/ConnectionSection.qml
 grep -Fq 'property string draftProxy: ""' components/ConnectionSection.qml
 grep -Fq 'id: proxyValue' components/ConnectionSection.qml
 grep -Fq 'anchors.right: parent.right' components/ConnectionSection.qml
-grep -Fq 'anchors.left: proxyLabel.right' components/ConnectionSection.qml
+grep -Fq 'anchors.right: proxyValue.left' components/ConnectionSection.qml
 grep -Fq 'text: "Apply"' components/ConnectionSection.qml
 grep -Fq 'text: "Cancel"' components/ConnectionSection.qml
 python3 - <<'PROXY_CANCEL'


### PR DESCRIPTION
Move the Proxy row edit icon from the label to immediately before the right-aligned proxy name, so the action sits beside the value it changes. Update DESIGN.md and the existing source assertion to match.

Validation: make validate passed (qmllint emitted module import and unqualified access warnings).