### PR TITLE
Persist a mode switch to the file mihomo starts from

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -194,6 +194,17 @@ A subscription URL is a bearer token — the whole of the authentication.
 - Where the panel and the CLI could disagree, the file on disk wins and the
   running core wins over both — the panel never shows a state nothing has
   confirmed.
+- **A mode switch is not done until `config.yaml` says so.** The service runs
+  `mihomo -d <root>`, which reads `config.yaml` and never `mihoro.toml` — that
+  file is only the template `mihoro apply` renders into it. So a switch is three
+  writes: `PATCH /configs` moves the running core, `mihoro.toml` records the
+  intent for the `mihoro apply` fallback, and `config.yaml` is what the next boot
+  starts from. Writing the first two alone was a real bug: the mode was right all
+  session and back to its old value after a reboot. The `config.yaml` write
+  follows a PATCH that landed and restarts nothing, because the core is already
+  serving that mode and a restart would drop every live connection to install a
+  value it holds. TUN is the deliberate exception — mihoro's TOML has no key for
+  it, so it is runtime-only and a restart restores the file.
 - The connection facts name the selectable node on its own `Proxy` label/value
   row. In Rule mode that means the live `PROXY` selector; in Global mode it
   means `GLOBAL`; Direct has no selector and says `DIRECT`. Editing expands the

--- a/Service.qml
+++ b/Service.qml
@@ -161,8 +161,10 @@ Item {
   readonly property bool canSwitchMode: Model.canSwitchMode(probe, apiState)
   readonly property string modeHint: Model.modeHint(probe, apiState)
 
-  // The API is the running truth; mihoro.toml is what survives a restart. They
-  // agree except in the window between a switch and the next refresh.
+  // The API is the running truth. `config.yaml` is what the next boot starts
+  // from and mihoro.toml is the template `mihoro apply` renders into it, so a
+  // switch writes all three; mihoro.toml stands in here only when the API is
+  // unreachable. They agree except between a switch and the next refresh.
   readonly property string mode: pendingMode !== "" ? pendingMode
     : (liveConfigs && liveConfigs.mode !== "" ? liveConfigs.mode : config.mode)
   readonly property string currentProxyGroup: mode === "rule" ? ruleProxyGroup
@@ -322,8 +324,9 @@ Item {
     lastError = ""
     optimismTimer.restart()
 
-    // Persisted first either way: if the PATCH lands, the file already agrees
-    // with the core; if it does not, the file is what `mihoro apply` reads.
+    // mihoro.toml first either way: if the PATCH is rejected, that file is what
+    // the `mihoro apply` fallback reads. It is not on its own enough to survive
+    // a restart — persistMode() writes `config.yaml` once the PATCH lands.
     // A write that could not start takes the optimistic chip back with it.
     if (!writeConfig({ mode: wanted }, apiBase === "" ? "apply" : "mode")) pendingMode = ""
   }
@@ -667,6 +670,36 @@ Item {
     lastError = ""
     configEnhancerProcess.command = enhancerCommand(kind)
     configEnhancerProcess.running = true
+  }
+
+  // The half of a mode switch that outlives a reboot. `PATCH /configs` moves the
+  // running core and `mihoro.toml` records the intent, but the service starts
+  // `mihomo -d <root>` — it reads `config.yaml` and nothing else, so a mode that
+  // never reached that file is back to its old value on the next boot.
+  //
+  // Runs after the PATCH landed, never instead of it: the user-visible switch is
+  // already done, this only writes it down. Hence no rules pass, no restart, no
+  // status line, and its own Process rather than the enhancer's — that one's
+  // exit is wired to the rules pipeline, and a mode write is not a rules action.
+  //
+  // A second switch lands while the first is still being written — two taps on
+  // the mode keys is enough — so the newer value is queued rather than dropped,
+  // like a node switch. Dropping it would leave `config.yaml` on the older mode
+  // with nothing said about it, which is the silent drift this path exists to
+  // end.
+  property string _queuedMode: ""
+
+  function persistMode(value) {
+    var wanted = ClashApi.normalizeMode(value)
+    if (wanted === "") return
+    if (modePersistProcess.running) {
+      _queuedMode = wanted
+      return
+    }
+    modePersistProcess.command = ["python3", enhancerPath, "mode",
+      "--config", mihomoConfigPath,
+      "--mode", wanted]
+    modePersistProcess.running = true
   }
 
   function installRuleTimer() {
@@ -1443,6 +1476,25 @@ Item {
   }
 
   Process {
+    id: modePersistProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: modePersistOut; waitForEnd: true }
+    stderr: StdioCollector { id: modePersistErr; waitForEnd: true }
+    onExited: function(exitCode) {
+      var queued = root._queuedMode
+      root._queuedMode = ""
+      // The switch itself worked — the core is serving the new mode and the chip
+      // is right. Only the part that outlives a restart failed, so this says so
+      // instead of taking a confirmation back that was never wrong.
+      if (exitCode !== 0)
+        root.reportError(Model.noticeMessage(modePersistErr.text
+          || "Switched, but the mode will not survive a restart."))
+      if (queued !== "") root.persistMode(queued)
+    }
+  }
+
+  Process {
     id: modeProcess
     running: false
     command: []
@@ -1451,6 +1503,9 @@ Item {
     onExited: function(exitCode) {
       var result = ClashApi.classify(exitCode, modeOut.text, modeErr.text)
       if (result.ok) {
+        // Before refreshApi(), which clears pendingMode the moment `/configs`
+        // agrees — the value has to be read while it is still there.
+        root.persistMode(root.pendingMode)
         root.actionStatus = "Switched to " + Model.modeLabel(root.pendingMode) + "."
         actionStatusTimer.restart()
         root.refreshApi()

--- a/scripts/config_enhancer.py
+++ b/scripts/config_enhancer.py
@@ -28,6 +28,8 @@ MANAGED_KEYS = (
     "geo-update-interval", "geox-url",
 )
 
+MODES = ("rule", "global", "direct")
+
 
 def load_yaml_bytes(raw):
     try:
@@ -158,20 +160,55 @@ def atomic_write(path, payload, mode):
             os.unlink(temporary)
 
 
+# mihomo starts from `config.yaml` and never reads `mihoro.toml` — that file is
+# only the template `mihoro apply` renders into it. So a mode that reached the
+# running core over `PATCH /configs` is gone by the next boot unless it is
+# written here too.
+#
+# Deliberately the whole of the change: no rules are recompiled, the core is not
+# asked to validate a one-key edit it already accepted over its own API, and the
+# service is not restarted. The core is serving this mode already; the file is
+# only catching up for next time, so touching the service would drop every live
+# connection to change nothing.
+def set_mode(config_path, mode):
+    if mode not in MODES:
+        raise ValueError("A proxy mode is required.")
+    raw = config_path.read_bytes()
+    current = load_yaml_bytes(raw)
+    if current.get("mode") == mode:
+        print("unchanged")
+        return
+    current["mode"] = mode
+    rendered = yaml.safe_dump(current, sort_keys=False, allow_unicode=True).encode("utf-8")
+    atomic_write(config_path, rendered, config_path.stat().st_mode & 0o777)
+    print("updated")
+
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("action", choices=("apply", "update"))
+    parser.add_argument("action", choices=("apply", "update", "mode"))
     parser.add_argument("--config", required=True, type=Path)
-    parser.add_argument("--rules", required=True, type=Path)
+    # Required by `apply` and `update`, checked below rather than by argparse:
+    # `mode` needs none of them, and a rules store it will not read has no
+    # business being on its command line.
+    parser.add_argument("--rules", type=Path)
     parser.add_argument("--subscriptions", type=Path)
     parser.add_argument("--mihoro-config", type=Path)
     parser.add_argument("--subscription-id")
-    parser.add_argument("--mihomo-bin", required=True)
-    parser.add_argument("--config-dir", required=True, type=Path)
+    parser.add_argument("--mode", choices=MODES)
+    parser.add_argument("--mihomo-bin")
+    parser.add_argument("--config-dir", type=Path)
     parser.add_argument("--systemctl", default="systemctl")
     parser.add_argument("--source", type=Path)
     parser.add_argument("--no-restart", action="store_true")
     args = parser.parse_args()
+
+    if args.action == "mode":
+        return set_mode(args.config, args.mode)
+
+    for name in ("rules", "mihomo_bin", "config_dir"):
+        if getattr(args, name) is None:
+            parser.error("--%s is required for %s." % (name.replace("_", "-"), args.action))
 
     if not args.subscription_id:
         if not args.subscriptions:

--- a/tests/test_config_enhancer.py
+++ b/tests/test_config_enhancer.py
@@ -216,4 +216,68 @@ with tempfile.TemporaryDirectory() as temp:
     finally:
         server.shutdown()
 
+# ---- persisting a mode switch --------------------------------------------
+#
+# mihomo starts from `config.yaml`; a mode that only ever reached the running
+# core over its API is back to the old value on the next boot. This is the
+# write that closes that gap, and it has to close it without disturbing
+# anything else in the file.
+
+with tempfile.TemporaryDirectory() as temp:
+    root = Path(temp)
+    config = root / "config.yaml"
+    config.write_text(yaml.safe_dump({
+        "port": 7891,
+        "mode": "global",
+        "external-controller": "0.0.0.0:9090",
+        "rules": ["GEOSITE,CN,DIRECT", "MATCH,PROXY"],
+        "proxies": [{"name": "Node", "type": "http", "server": "example.com", "port": 443}],
+    }, sort_keys=False))
+    config.chmod(0o600)
+
+    def run_mode(*extra, expect=0):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "mode", "--config", str(config), *extra],
+            text=True, capture_output=True)
+        assert result.returncode == expect, result.stderr
+        return result
+
+    # Nothing but `mode` moves: the rules the panel prepended, the proxies, and
+    # the local overrides are all still there afterwards.
+    assert run_mode("--mode", "rule").stdout.strip() == "updated"
+    written = yaml.safe_load(config.read_text())
+    assert written["mode"] == "rule"
+    assert written["rules"] == ["GEOSITE,CN,DIRECT", "MATCH,PROXY"]
+    assert written["proxies"][0]["name"] == "Node"
+    assert written["external-controller"] == "0.0.0.0:9090"
+    assert written["port"] == 7891
+    # `mode` keeps its place rather than being appended: the file stays the
+    # shape mihoro and the enhancer both write it in.
+    assert list(written)[:3] == ["port", "mode", "external-controller"]
+    # config.yaml carries the subscription; the write must not widen it.
+    assert config.stat().st_mode & 0o777 == 0o600
+
+    # Re-switching to the mode already on disk rewrites nothing, so a switch
+    # back and forth cannot churn the file.
+    assert run_mode("--mode", "rule").stdout.strip() == "unchanged"
+
+    # No rules store, no mihomo binary, no config dir — the mode write needs
+    # none of them, and requiring them would be a lie about what it reads.
+    assert run_mode("--mode", "direct").stdout.strip() == "updated"
+    assert yaml.safe_load(config.read_text())["mode"] == "direct"
+
+    # Only the three modes mihomo has. argparse rejects the rest before any
+    # file is opened.
+    run_mode("--mode", "sideways", expect=2)
+    run_mode(expect=1)
+    assert yaml.safe_load(config.read_text())["mode"] == "direct"
+
+    # The other actions still say what they need, now that argparse no longer
+    # says it for them.
+    missing = subprocess.run(
+        [sys.executable, str(SCRIPT), "apply", "--config", str(config)],
+        text=True, capture_output=True)
+    assert missing.returncode == 2, missing.stderr
+    assert "--rules is required" in missing.stderr
+
 print("config enhancer tests passed")

--- a/tests/test_panel_source.sh
+++ b/tests/test_panel_source.sh
@@ -18,11 +18,32 @@ refute() {
 
 # ---- mode switching -------------------------------------------------------
 
-# The API changes the running core in place; the file is what survives a
-# restart. A switch must do both, in that order, or the two disagree.
+# The API changes the running core in place; `config.yaml` is what the next boot
+# starts from. A switch must do both, or the mode is back to its old value after
+# a reboot — mihomo reads `config.yaml` and never `mihoro.toml`, so writing the
+# TOML alone (which is all this did once) persists nothing.
 grep -Fq 'writeConfig({ mode: wanted }' Service.qml
 grep -Fq 'ClashApi.setModeCommand' Service.qml
 grep -Fq 'Model.applyCommand()' Service.qml
+grep -Fq 'root.persistMode(root.pendingMode)' Service.qml
+grep -Fq '"python3", enhancerPath, "mode",' Service.qml
+# Persistence follows a PATCH that landed, so it writes and stops: restarting to
+# install a mode the core is already serving would drop every live connection to
+# change nothing, and a mode write is not a rules action.
+set_mode_body="$(sed -n '/^def set_mode/,/^def main/p' scripts/config_enhancer.py)"
+# Without this the two refutes below pass on an empty extraction — deleting
+# set_mode outright would leave the rule green with nothing holding it.
+grep -Fq 'def set_mode' <<<"$set_mode_body"
+refute -Fq 'restart' <<<"$set_mode_body"
+refute -Fq 'rules' <<<"$set_mode_body"
+# Its own Process: the enhancer's exit is wired to the rules pipeline, and
+# borrowing it would report a mode write as "Local rules applied."
+grep -Fq 'id: modePersistProcess' Service.qml
+refute -Fq 'runConfigEnhancer("mode"' Service.qml
+# Latest wins, like a node switch: a mode written while the previous write is
+# still running is queued, never dropped on the floor to drift in silence.
+grep -Fq 'root._queuedMode = ""' Service.qml
+grep -Fq 'if (queued !== "") root.persistMode(queued)' Service.qml
 # A rejected PATCH falls back to a restart rather than leaving the click on the
 # floor.
 grep -Fq 'root.runAction("apply"' Service.qml


### PR DESCRIPTION
Switching Rule/Global/Direct holds for the session and then comes back on the
old mode after a restart.

The switch writes `mihoro.toml` and patches the running core, but the service
runs `mihomo -d <root>` — mihomo reads `config.yaml` and never `mihoro.toml`,
which is only the template `mihoro apply` renders into it. Nothing ever put the
new mode into the file the next boot actually starts from.

## Reproduction

Needs `external_controller` set in `~/.config/mihoro.toml`, so the panel reaches
the API and takes the `PATCH /configs` path rather than the `mihoro apply` one.

1. Note the mode the core will start on:

   ```bash
   grep -m1 '^mode:' ~/.config/mihomo/config.yaml     # mode: global
   ```

2. Open the panel and switch the mode — Global to Rule. The chip moves, and the
   switch is real: new connections are matched under Rule straight away.

3. Ask all three sources what the mode is:

   ```bash
   curl -s http://127.0.0.1:9090/configs | jq -r .mode  # rule    <- the core
   grep -m1 '^mode' ~/.config/mihoro.toml               # "rule"  <- the template
   grep -m1 '^mode:' ~/.config/mihomo/config.yaml       # global  <- what boots
   ```

   `config.yaml` never moved.

4. Restart the core (a reboot does the same):

   ```bash
   systemctl --user restart mihomo.service
   curl -s http://127.0.0.1:9090/configs | jq -r .mode  # global
   ```

The mode is back where it started, with nothing said about it. On the machine
this was found on, `mihoro.toml` had said `rule` since the previous evening
while the core and `config.yaml` had both been `global` since the last
subscription update — `config_enhancer.py` carries `mode` forward from the
current `config.yaml` on every update, so the drift never heals on its own.

## What

A successful `PATCH /configs` is now followed by a write of the same mode into
`config.yaml`. The runtime half is unchanged, so the switch still takes effect
on the next connection with no restart — the file is only catching up for next
time, and restarting to install a mode the core is already serving would drop
every live connection to change nothing.

The `mihoro apply` fallback (no reachable API, or a rejected PATCH) was already
correct and is untouched: it renders `mihoro.toml` into `config.yaml` and leaves
the panel's prepended local rules intact.

## How

- `config_enhancer.py` gains a `mode` action: read `config.yaml`, set one key,
  write it back atomically with the file's own permissions. No rules pass, no
  `mihomo -t` on a one-key edit the core just accepted over its own API, no
  restart. `--rules`, `--mihomo-bin` and `--config-dir` move from argparse's
  `required` to a per-action check, because `mode` reads none of them.
- `Service.qml` gains `persistMode()` and its own `Process`, called from
  `modeProcess.onExited` before `refreshApi()` clears `pendingMode`. A failure
  reports that the mode will not survive a restart rather than taking back a
  confirmation that was never wrong — the core did switch.
- A second switch arriving while the first is still being written is queued
  rather than dropped, like a node switch. Dropping it would leave `config.yaml`
  on the older mode with nothing said about it, which is the silent drift this
  path exists to end.
- `DESIGN.md` records the three-writes rule and why TUN stays the deliberate
  runtime-only exception (mihoro's TOML has no `tun` key to persist into).

## Verification

`make validate` passes.

`tests/test_config_enhancer.py` asserts the write moves `mode` and nothing else:
rules, proxies and local overrides all survive, the key keeps its position,
`0600` is not widened, a no-op switch rewrites nothing, and `apply`/`update`
still report their own missing arguments now that argparse no longer does.

`tests/test_panel_source.sh` pins the call site, the queue, and — via `refute` —
that `set_mode` neither restarts nor touches rules. Each new assertion was
checked to actually fail when its subject is removed; one first draft of the
`refute` pair passed on an empty extraction and was fixed to require
`def set_mode` first.

The `mihoro apply` fallback was verified in a sandbox with a `systemctl` stub on
`PATH` (mihoro invokes `systemctl` by bare name, so the stub intercepts the
restart): it does write the TOML's mode into `config.yaml`, and it does preserve
the 425 prepended rules — so that path needed no change.

Fix confirmed against the reproduction above: after switching, `config.yaml`
now carries the new mode, and the core comes back on it after
`systemctl --user restart mihomo.service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
